### PR TITLE
Post item layout fixes

### DIFF
--- a/res/layout/list_item_post.xml
+++ b/res/layout/list_item_post.xml
@@ -31,11 +31,13 @@
 
 			<TextView
 				android:id="@+id/index"
+				style="@style/Widget.HeaderText"
 				android:layout_width="wrap_content"
 				android:layout_height="wrap_content" />
 
 			<TextView
 				android:id="@+id/name"
+				style="@style/Widget.HeaderText"
 				android:layout_width="match_parent"
 				android:layout_height="wrap_content"
 				android:ellipsize="end"
@@ -43,6 +45,7 @@
 
 			<TextView
 				android:id="@+id/number"
+				style="@style/Widget.HeaderText"
 				android:layout_width="wrap_content"
 				android:layout_height="wrap_content" />
 

--- a/src/com/mishiranu/dashchan/ui/navigator/manager/ViewUnit.java
+++ b/src/com/mishiranu/dashchan/ui/navigator/manager/ViewUnit.java
@@ -77,8 +77,6 @@ public class ViewUnit {
 	private static final float ALPHA_HIDDEN_POST = 0.2f;
 	private static final float ALPHA_DELETED_POST = 0.5f;
 
-	private static final float MEDIA_ITEM_RESIZE_COEFFICIENT = 1.5f;
-
 	@SuppressLint("InflateParams")
 	ViewUnit(UiManager uiManager) {
 		Context context = uiManager.getContext();
@@ -545,7 +543,7 @@ public class ViewUnit {
 				int holders = attachmentHolders.size();
 				if (holders < size) {
 					int postBackgroundColor = getPostBackgroundColor(uiManager.getContext(), configurationSet);
-					float thumbnailsScale = Preferences.getThumbnailsScale() * MEDIA_ITEM_RESIZE_COEFFICIENT;
+					float thumbnailsScale = Preferences.getThumbnailsScale();
 					float textScale = Preferences.getTextScale();
 					for (int i = holders; i < size; i++) {
 						View view = LayoutInflater.from(context).inflate(R.layout.list_item_post_attachment, null);
@@ -1359,7 +1357,7 @@ public class ViewUnit {
 			this.dimensions = dimensions.get(this);
 			thumbnail.setDrawTouching(true);
 			ViewGroup.LayoutParams thumbnailLayoutParams = thumbnail.getLayoutParams();
-			float thumbnailsScale = Preferences.getThumbnailsScale() * MEDIA_ITEM_RESIZE_COEFFICIENT;
+			float thumbnailsScale = Preferences.getThumbnailsScale();
 			if (thumbnailsScale != 1f) {
 				thumbnailLayoutParams.width = (int) (this.dimensions.thumbnailWidth * thumbnailsScale);
 				thumbnailLayoutParams.height = thumbnailLayoutParams.width;


### PR DESCRIPTION
Заметил, что после фикса уезжающей за экран метадаты (1083c29) разметка постов опять поломалась.

Так выглядит сейчас:
<img align="top" src="https://user-images.githubusercontent.com/16612598/221541242-509d0171-249c-49b3-8234-ded63429b7dc.png" width=400/> <img src="https://user-images.githubusercontent.com/16612598/221541339-aba1cc40-1bc4-4084-8672-f063a5c6bfd7.png" width=300 height=400/>
1. Большое изображение.
2. Из-за отсутствия стилей текст номера индекса, номера поста и имени отправителя отличаются от остального текста.

С моими изменениями будет выглядеть как раньше:
<img align="top" src="https://user-images.githubusercontent.com/16612598/221537401-abae7ddd-e1cd-40bb-88f9-ea14c0ab83f6.png" width=400/> <img src="https://user-images.githubusercontent.com/16612598/221543060-aca02321-758d-4978-9804-5b02a0362809.png" width=400/>
