### PR TITLE
Fix usage of user-agent header name instead of value

### DIFF
--- a/src/chan/http/HttpClient.java
+++ b/src/chan/http/HttpClient.java
@@ -449,7 +449,7 @@ public class HttpClient {
 					}
 					connection.setRequestProperty(header.first, header.second);
 					if ("User-Agent".equalsIgnoreCase(header.first)) {
-						userAgent = header.first;
+						userAgent = header.second;
 						userAgentSet = true;
 					}
 					if ("Accept-Encoding".equalsIgnoreCase(header.first)) {


### PR DESCRIPTION
Исправил ошибку, из-за которой вместо значения юзер-агента использовалось название заголовка.