### PR TITLE
Cloudflare resolving improvements

### DIFF
--- a/src/chan/http/FirewallResolver.java
+++ b/src/chan/http/FirewallResolver.java
@@ -7,6 +7,7 @@ import chan.content.Chan;
 import chan.content.ChanConfiguration;
 import com.mishiranu.dashchan.content.net.firewall.FirewallResolvers;
 import java.util.Map;
+import java.util.Objects;
 
 @Extendable
 public abstract class FirewallResolver {
@@ -38,37 +39,31 @@ public abstract class FirewallResolver {
 	public static final class Identifier {
 		@Public
 		public enum Flag {
-			@Public USER_AGENT
+			@Public USER_AGENT,
+			HOST
 		}
 
 		@Public public final String userAgent;
 		@Public public final boolean defaultUserAgent;
+		public final String host;
 
-		public Identifier(String userAgent, boolean defaultUserAgent) {
+		public Identifier(String userAgent, boolean defaultUserAgent, String host) {
 			this.userAgent = userAgent;
 			this.defaultUserAgent = defaultUserAgent;
+			this.host = host;
 		}
 
 		@Override
 		public boolean equals(Object o) {
-			if (o == this) {
-				return true;
-			}
-			if (o instanceof Identifier) {
-				Identifier identifier = (Identifier) o;
-				return userAgent.equals(identifier.userAgent) &&
-						defaultUserAgent == identifier.defaultUserAgent;
-			}
-			return false;
+			if (this == o) return true;
+			if (o == null || getClass() != o.getClass()) return false;
+			Identifier that = (Identifier) o;
+			return defaultUserAgent == that.defaultUserAgent && Objects.equals(userAgent, that.userAgent) && Objects.equals(host, that.host);
 		}
 
 		@Override
 		public int hashCode() {
-			int prime = 31;
-			int result = 1;
-			result = prime * result + userAgent.hashCode();
-			result = prime * result + (defaultUserAgent ? 1 : 0);
-			return result;
+			return Objects.hash(userAgent, defaultUserAgent, host);
 		}
 	}
 

--- a/src/chan/http/HttpClient.java
+++ b/src/chan/http/HttpClient.java
@@ -474,7 +474,7 @@ public class HttpClient {
 				connection.setRequestProperty("Accept-Encoding", acceptEncoding.toString());
 			}
 			FirewallResolver.Identifier resolverIdentifier = new FirewallResolver
-					.Identifier(userAgent, !userAgentSet);
+					.Identifier(userAgent, !userAgentSet, url.getHost());
 			CookieBuilder cookieBuilder = !session.mayCheckFirewallBlock
 					? request.cookieBuilder : obtainModifiedCookieBuilder(request.cookieBuilder,
 					session.holder.chan, requestedUri, resolverIdentifier);

--- a/src/chan/http/WebSocket.java
+++ b/src/chan/http/WebSocket.java
@@ -449,7 +449,7 @@ public final class WebSocket {
 				requestBuilder.append("User-Agent: ").append(userAgent.replaceAll("[\r\n]", "")).append("\r\n");
 			}
 			FirewallResolver.Identifier resolverIdentifier = new FirewallResolver
-					.Identifier(userAgent, addUserAgent);
+					.Identifier(userAgent, addUserAgent, url.getHost());
 			CookieBuilder cookieBuilder = client.obtainModifiedCookieBuilder(this.cookieBuilder,
 					holder.chan, uri, resolverIdentifier);
 			if (cookieBuilder != null) {

--- a/src/com/mishiranu/dashchan/content/net/firewall/CloudFlareResolver.java
+++ b/src/com/mishiranu/dashchan/content/net/firewall/CloudFlareResolver.java
@@ -2,101 +2,69 @@ package com.mishiranu.dashchan.content.net.firewall;
 
 import android.net.Uri;
 import android.os.Parcel;
+
+import com.mishiranu.dashchan.R;
+import com.mishiranu.dashchan.content.MainApplication;
+import com.mishiranu.dashchan.content.Preferences;
+import com.mishiranu.dashchan.content.service.webview.WebViewExtra;
+import com.mishiranu.dashchan.util.IOUtils;
+
+import java.net.HttpURLConnection;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import chan.content.Chan;
 import chan.http.CookieBuilder;
 import chan.http.FirewallResolver;
 import chan.http.HttpException;
 import chan.http.HttpResponse;
 import chan.util.StringUtils;
-import com.mishiranu.dashchan.R;
-import com.mishiranu.dashchan.content.MainApplication;
-import com.mishiranu.dashchan.content.Preferences;
-import com.mishiranu.dashchan.content.service.webview.WebViewExtra;
-import com.mishiranu.dashchan.util.IOUtils;
-import java.net.HttpURLConnection;
-import java.util.Map;
 
 public class CloudFlareResolver extends FirewallResolver {
 	private static final String COOKIE_CLOUDFLARE = "cf_clearance";
-	private static final String[] TITLES = {"Attention Required! | Cloudflare", "Just a moment...", "Please wait…"};
 
-	private static class CookieResult {
-		public final String cookie;
-		public final Uri uri;
-
-		public CookieResult(String cookie, Uri uri) {
-			this.cookie = cookie;
-			this.uri = uri;
+	@Override
+	public CheckResponseResult checkResponse(Session session, HttpResponse response) throws HttpException {
+		boolean pageBlockedByCloudflare = pageBlocked(response) && (responseContainsCloudflareHeaders(response) || responseContainsCloudflareTitle(response));
+		if (pageBlockedByCloudflare) {
+			return new CheckResponseResult(toKey(session), new Exclusive());
+		} else {
+			return null;
 		}
 	}
 
-	private static class Extra implements WebViewExtra {
-		@Override
-		public String getInjectJavascript() {
-			return IOUtils.readRawResourceString(MainApplication.getInstance().getResources(),
-					R.raw.web_cloudflare_inject);
-		}
-
-		public static final Creator<Extra> CREATOR = new Creator<Extra>() {
-			@Override
-			public Extra createFromParcel(Parcel in) {
-				return new Extra();
-			}
-
-			@Override
-			public Extra[] newArray(int size) {
-				return new Extra[0];
-			}
-		};
+	private boolean pageBlocked(HttpResponse response) {
+		int responseCode = response.getResponseCode();
+		return responseCode == HttpURLConnection.HTTP_FORBIDDEN || responseCode == HttpURLConnection.HTTP_UNAVAILABLE;
 	}
 
-	private static class WebViewClient extends FirewallResolvers.WebViewClientWithExtra<CookieResult> {
-		private final String title;
-
-		public WebViewClient(String title) {
-			super("CloudFlare", new Extra());
-			this.title = title;
+	private boolean responseContainsCloudflareHeaders(HttpResponse response) {
+		Map<String, List<String>> responseHeaders = response.getHeaderFields();
+		boolean responseContainsCloudflareRayHeader = responseHeaders.containsKey("CF-RAY");
+		if (!responseContainsCloudflareRayHeader) {
+			List<String> serverHeader = responseHeaders.get("Server");
+			return serverHeader != null && serverHeader.contains("cloudflare");
 		}
+		return true;
+	}
 
-		@Override
-		public boolean onPageFinished(Uri uri, Map<String, String> cookies, String title) {
-			if (title != null && title.equals(this.title)) {
-				return false;
-			}
-			for (String checkTitle : TITLES) {
-				if (checkTitle.equals(title)) {
-					return false;
+	// Cloudflare uses localized titles in some challenges, so this method is very unreliable
+	private boolean responseContainsCloudflareTitle(HttpResponse response) throws HttpException {
+		Pattern titlePattern = Pattern.compile("<title>(.*?)</title>");
+		String responseText = response.readString();
+		Matcher titleMatcher = titlePattern.matcher(responseText);
+		if (titleMatcher.find()) {
+			String[] cloudflareTitles = {"Attention Required! | Cloudflare", "Just a moment...", "Please wait…"};
+			String title = titleMatcher.group(1);
+			for (String cloudflareTitle : cloudflareTitles) {
+				if (cloudflareTitle.equals(title)) {
+					return true;
 				}
 			}
-			String cookie = cookies.get(COOKIE_CLOUDFLARE);
-			setResult(cookie != null ? new CookieResult(cookie, uri) : null);
-			return true;
 		}
-
-		@Override
-		public boolean onLoad(Uri initialUri, Uri uri) {
-			String path = uri.getPath();
-			return path == null || path.isEmpty() || "/".equals(path) ||
-					path.equals(initialUri.getPath()) || path.startsWith("/cdn-cgi/");
-		}
-	}
-
-	private class Exclusive implements FirewallResolver.Exclusive {
-		public final String title;
-
-		public Exclusive(String title) {
-			this.title = title;
-		}
-
-		@Override
-		public boolean resolve(Session session, Key key) throws CancelException, InterruptedException {
-			CookieResult result = session.resolveWebView(new WebViewClient(title));
-			if (result != null) {
-				storeCookie(session, key, result.cookie, result.uri);
-				return true;
-			}
-			return false;
-		}
+		return false;
 	}
 
 	private Exclusive.Key toKey(Session session) {
@@ -104,37 +72,13 @@ public class CloudFlareResolver extends FirewallResolver {
 	}
 
 	@Override
-	public CheckResponseResult checkResponse(Session session, HttpResponse response) throws HttpException {
-		int responseCode = response.getResponseCode();
-		if ((responseCode == HttpURLConnection.HTTP_FORBIDDEN || responseCode == HttpURLConnection.HTTP_UNAVAILABLE)
-				&& response.getHeaderFields().containsKey("CF-RAY")) {
-			String responseText = response.readString();
-			switch (responseCode) {
-				case HttpURLConnection.HTTP_FORBIDDEN:
-				case HttpURLConnection.HTTP_UNAVAILABLE: {
-					String title = null;
-					for (String checkTitle : TITLES) {
-						if (responseText.contains("<title>" + checkTitle + "</title>")) {
-							title = checkTitle;
-						}
-					}
-					if (responseText.contains("<form class=\"challenge-form\" id=\"challenge-form\"") &&
-							(responseText.contains("__cf_chl_captcha_tk__") || responseText.contains("__cf_chl_f_tk"))) {
-						int start = responseText.indexOf("<title>");
-						if (start >= 0) {
-							int end = responseText.indexOf("</title>", start);
-							if (end > start) {
-								title = responseText.substring(start + 7, end);
-							}
-						}
-					}
-					if (title != null) {
-						return new CheckResponseResult(toKey(session), new Exclusive(title));
-					}
-				}
-			}
+	public void collectCookies(Session session, CookieBuilder cookieBuilder) {
+		Chan chan = session.getChan();
+		Exclusive.Key key = toKey(session);
+		String cookie = chan.configuration.getCookie(key.formatKey(COOKIE_CLOUDFLARE));
+		if (!StringUtils.isEmpty(cookie)) {
+			cookieBuilder.append(COOKIE_CLOUDFLARE, cookie);
 		}
-		return null;
 	}
 
 	private void storeCookie(Session session, Exclusive.Key key, String cookie, Uri uri) {
@@ -151,13 +95,70 @@ public class CloudFlareResolver extends FirewallResolver {
 		}
 	}
 
-	@Override
-	public void collectCookies(Session session, CookieBuilder cookieBuilder) {
-		Chan chan = session.getChan();
-		Exclusive.Key key = toKey(session);
-		String cookie = chan.configuration.getCookie(key.formatKey(COOKIE_CLOUDFLARE));
-		if (!StringUtils.isEmpty(cookie)) {
-			cookieBuilder.append(COOKIE_CLOUDFLARE, cookie);
+	private static class CookieResult {
+		public final String cookie;
+		public final Uri uri;
+
+		public CookieResult(String cookie, Uri uri) {
+			this.cookie = cookie;
+			this.uri = uri;
+		}
+	}
+
+	private static class Extra implements WebViewExtra {
+		public static final Creator<Extra> CREATOR = new Creator<Extra>() {
+			@Override
+			public Extra createFromParcel(Parcel in) {
+				return new Extra();
+			}
+
+			@Override
+			public Extra[] newArray(int size) {
+				return new Extra[0];
+			}
+		};
+
+		@Override
+		public String getInjectJavascript() {
+			return IOUtils.readRawResourceString(MainApplication.getInstance().getResources(),
+					R.raw.web_cloudflare_inject);
+		}
+	}
+
+	private static class WebViewClient extends FirewallResolvers.WebViewClientWithExtra<CookieResult> {
+
+		public WebViewClient() {
+			super("CloudFlare", new Extra());
+		}
+
+		@Override
+		public boolean onPageFinished(Uri uri, Map<String, String> cookies, String title) {
+			String cookie = cookies.get(COOKIE_CLOUDFLARE);
+			if (cookie == null) {
+				return false;
+			}
+			setResult(new CookieResult(cookie, uri));
+			return true;
+		}
+
+		@Override
+		public boolean onLoad(Uri initialUri, Uri uri) {
+			String path = uri.getPath();
+			return path == null || path.isEmpty() || "/".equals(path) ||
+					path.equals(initialUri.getPath()) || path.startsWith("/cdn-cgi/");
+		}
+	}
+
+	private class Exclusive implements FirewallResolver.Exclusive {
+
+		@Override
+		public boolean resolve(Session session, Key key) throws CancelException, InterruptedException {
+			CookieResult result = session.resolveWebView(new WebViewClient());
+			if (result != null) {
+				storeCookie(session, key, result.cookie, result.uri);
+				return true;
+			}
+			return false;
 		}
 	}
 }

--- a/src/com/mishiranu/dashchan/content/net/firewall/CloudFlareResolver.java
+++ b/src/com/mishiranu/dashchan/content/net/firewall/CloudFlareResolver.java
@@ -68,7 +68,7 @@ public class CloudFlareResolver extends FirewallResolver {
 	}
 
 	private Exclusive.Key toKey(Session session) {
-		return session.getKey(Identifier.Flag.USER_AGENT);
+		return session.getKey(Identifier.Flag.USER_AGENT, Identifier.Flag.HOST);
 	}
 
 	@Override
@@ -83,8 +83,9 @@ public class CloudFlareResolver extends FirewallResolver {
 
 	private void storeCookie(Session session, Exclusive.Key key, String cookie, Uri uri) {
 		Chan chan = session.getChan();
+		String cookieTitle = "Cloudflare " + session.getUri().getHost();
 		chan.configuration.storeCookie(key.formatKey(COOKIE_CLOUDFLARE), cookie,
-				cookie != null ? key.formatTitle("CloudFlare") : null);
+				cookie != null ? key.formatTitle(cookieTitle) : null);
 		chan.configuration.commit();
 		if (uri != null) {
 			String host = uri.getHost();

--- a/src/com/mishiranu/dashchan/content/net/firewall/FirewallResolvers.java
+++ b/src/com/mishiranu/dashchan/content/net/firewall/FirewallResolvers.java
@@ -137,6 +137,9 @@ public class FirewallResolvers extends FirewallResolver.Implementation {
 						}
 						break;
 					}
+					case HOST:
+						generator.append("host", identifier.host);
+						break;
 					default: {
 						throw new IllegalArgumentException();
 					}

--- a/src/com/mishiranu/dashchan/util/NavigationUtils.java
+++ b/src/com/mishiranu/dashchan/util/NavigationUtils.java
@@ -78,7 +78,7 @@ public class NavigationUtils {
 				if (chan.locator.safe(false).isAttachmentUri(uri)) {
 					String userAgent = AdvancedPreferences.getUserAgent(chanName);
 					FirewallResolver.Identifier resolverIdentifier = new FirewallResolver
-							.Identifier(userAgent, true);
+							.Identifier(userAgent, true, uri.getHost());
 					CookieBuilder cookieBuilder = FirewallResolver.Implementation.getInstance()
 							.collectCookies(chan, uri, resolverIdentifier, true);
 					if (!cookieBuilder.isEmpty()) {


### PR DESCRIPTION
Убрал проверку заголовка страницы из метода, который отвечает за сбор куки при прохождении Клаудфлары. Дело в том, что Клаудфлара в процессе проверки может изменить заголовок страницы на локализованный через какое то время после загрузки страницы. Если, например, устройство использует русский язык, то заголовок "Just a moment..." меняется на "Один момент...". Из-за этого при проверке заголовка страницы метод считает, что Клаудфлара пройдена и пришло время собирать куки, но куки не доступны, так как проверка на самом деле еще не пройдена, просто заголовок изменился на локализованный. Теперь проверка Клаудфлары считается пройденной только тогда, когда куки доступны. 

Оставил проверку заголовка страницы в методе, который отвечает за проверку, заблокирована ли страница Клаудфларой или нет, но он используется в последнюю очередь. Возможно, его  стоит вообще удалить, ибо в теории он не будет вызван никогда, так как перед ним проверяется наличие HTTP заголовков Клаудфлары, а они всегда присутствуют, если страница заблокирована.

Так же добавил возможность различать Firewall Resolver по хосту. Это нужно в ситуации, когда чан имеет разные хосты для борд (форчан, например, имеет разные хосты для зелёных и синих борд). Теперь для разных хостов будут использоваться свои куки фаервола. Пока реализовано только для Клаудфлары, но при надобности можно  добавить и для других фаерволов.

