### PR TITLE
Fix missing progressbar in webview dialog

### DIFF
--- a/res/layout/dialog_webview.xml
+++ b/res/layout/dialog_webview.xml
@@ -71,7 +71,6 @@
             android:tag="theme.progressTint=accent"
             tools:alpha="1"
             tools:progress="50"
-            android:visibility="gone"
             tools:progressTint="@android:color/holo_purple" />
 
     </FrameLayout>

--- a/src/com/mishiranu/dashchan/ui/WebViewDialog.java
+++ b/src/com/mishiranu/dashchan/ui/WebViewDialog.java
@@ -104,7 +104,7 @@ public abstract class WebViewDialog extends DialogFragment {
 
 		private void animateProgressBarVisibility(int newProgress) {
 			boolean animateHide = newProgress == 100 && lastProgress != 100;
-			boolean animateShow = newProgress != 100 && lastProgress == 100;
+			boolean animateShow = lastProgress == 0 || (newProgress != 100 && lastProgress == 100);
 			boolean animate = animateHide || animateShow;
 			if (animate) {
 				if (progressBarVisibilityAnimator.isRunning()) {


### PR DESCRIPTION
Убрал visibility:gone у прогресс бара (скорее всего тестировал что-то и забыл убрать перед коммитом) и заодно исправил баг, когда прогресс бар не появлялся при первой загрузке страницы. 