### PR TITLE
TrixiEther | Issue with changelogs

### DIFF
--- a/metadata/en-US/changelogs/1046.txt
+++ b/metadata/en-US/changelogs/1046.txt
@@ -1,1 +1,2 @@
-* Added the ability to hide threads with a swipe (activated in the settings)
+* Fix with UserAgent to bypass Cloudflare DDoS protection
+* Fixed a crash issue when using swipe to hide threads

--- a/metadata/ru/changelogs/1046.txt
+++ b/metadata/ru/changelogs/1046.txt
@@ -1,2 +1,2 @@
-* Fix with UserAgent to bypass Cloudflare DDoS protection
-* Fixed a crash issue when using swipe to hide threads
+* Исправлен UserAgent для обхода защиты Cloudflare от DDoS.
+* Исправлена проблема с вылетом при использовании свайпа для скрытия тем.

--- a/src/com/mishiranu/dashchan/content/async/ReadChangelogTask.java
+++ b/src/com/mishiranu/dashchan/content/async/ReadChangelogTask.java
@@ -25,6 +25,9 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 public class ReadChangelogTask extends ExecutorTask<Void, Pair<ErrorItem, List<ReadChangelogTask.Entry>>> {
+
+	private static final String PREFIX_EXPERIMENTAL_VERSION = "3.1.4-experimental-";
+
 	public interface Callback {
 		void onReadChangelogComplete(List<Entry> entries, ErrorItem errorItem);
 	}
@@ -40,9 +43,19 @@ public class ReadChangelogTask extends ExecutorTask<Void, Pair<ErrorItem, List<R
 			}
 
 			public String getMajorMinor() {
+				if (name.contains(PREFIX_EXPERIMENTAL_VERSION)) {
+					return getExperimentalMajorMinor();
+				}
 				int index = name.indexOf('.');
 				index = name.indexOf('.', index + 1);
 				return index >= 0 ? name.substring(0, index) : name;
+			}
+
+			private String getExperimentalMajorMinor() {
+				String experimentalName = name.replace(PREFIX_EXPERIMENTAL_VERSION, "");
+				int index = experimentalName.indexOf('.');
+				index = experimentalName.indexOf('.', index + 1);
+				return index >= 0 ? experimentalName.substring(0, index) : name;
 			}
 		}
 


### PR DESCRIPTION
Fixed the display of the list of changes. The name is already taken as it is, so MinogMajor will be taken from the specific experimental version (maybe we should have a simpler name for the fork in the future...)

+ Fixed incorrect display of changes for 1046 in Russian localization. Since Dashchan collects changelogs from GitHub, the changes should take effect as soon as this pull request is merged into the default branch (probably)

Closes #47 