### PR TITLE
Fix overscroll glow bugs

### DIFF
--- a/src/com/mishiranu/dashchan/C.java
+++ b/src/com/mishiranu/dashchan/C.java
@@ -21,6 +21,7 @@ public class C {
 	public static final boolean API_PIE = Build.VERSION.SDK_INT >= Build.VERSION_CODES.P;
 	public static final boolean API_Q = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q;
 	public static final boolean API_R = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R;
+	public static final boolean API_S = Build.VERSION.SDK_INT >= 31;
 
 	public static final boolean USE_SAF = API_MARSHMALLOW;
 

--- a/src/com/mishiranu/dashchan/widget/EdgeEffectHandler.java
+++ b/src/com/mishiranu/dashchan/widget/EdgeEffectHandler.java
@@ -75,11 +75,15 @@ public class EdgeEffectHandler {
 				int shift = this.shift.getEdgeEffectShift(side);
 				boolean needShift = shift != 0;
 				if (needShift) {
-					if (C.API_LOLLIPOP) {
-						int color = getColor();
-						Paint paint = shiftPaint;
-						paint.setColor(color);
-						canvas.drawRect(0, 0, width, shift, paint);
+					boolean deviceSupportsOverscrollGlow = C.API_LOLLIPOP && !C.API_S;
+					if (deviceSupportsOverscrollGlow) {
+						int overscrollGlowColor = getColor();
+						int overscrollGlowAlpha = (0xff000000 & overscrollGlowColor) >> 24;
+						if (overscrollGlowAlpha >= 0) {
+							Paint paint = shiftPaint;
+							paint.setColor(overscrollGlowColor);
+							canvas.drawRect(0, 0, width, shift, paint);
+						}
 					}
 					canvas.save();
 					canvas.translate(0, shift);


### PR DESCRIPTION
Fixes this bug for Android 12+:

![overscroll_glow_bug_android12](https://user-images.githubusercontent.com/16612598/235698416-7094c671-ff1f-466d-85cd-3aa2fc227f1d.gif)

For devices that support overscroll glow fixes this bug:

![overscroll_glow_bug_android_pre_12](https://user-images.githubusercontent.com/16612598/235700295-f7922c1a-2125-4007-824b-ecf34905ba45.gif)
