### PR TITLE
Complete hiding of posts

### DIFF
--- a/lang/values-ru/strings.xml
+++ b/lang/values-ru/strings.xml
@@ -120,6 +120,8 @@
 	<string name="details">Подробнее</string>
 	<string name="disabled">Отключено</string>
 	<string name="display_hidden_threads">Выводить скрытые треды</string>
+	<string name="display_hidden_posts">Выводить скрытые посты</string>
+	<string name="display_hidden_posts__summary">Отключение функции полностью убирает отображение постов, которые были автоматически скрыты</string>
 	<string name="display_post_icons">Показывать иконки сообщений</string>
 	<string name="display_post_icons__summary">Иконки доступны в некоторых разделах</string>
 	<string name="do_nothing">Ничего не делать</string>

--- a/lang/values-ru/strings.xml
+++ b/lang/values-ru/strings.xml
@@ -121,7 +121,7 @@
 	<string name="disabled">Отключено</string>
 	<string name="display_hidden_threads">Выводить скрытые треды</string>
 	<string name="display_hidden_posts">Выводить скрытые посты</string>
-	<string name="display_hidden_posts__summary">Отключение функции полностью убирает отображение постов, которые были автоматически скрыты</string>
+	<string name="display_hidden_posts__summary">Отключение функции полностью убирает отображение постов, которые были скрыты</string>
 	<string name="display_post_icons">Показывать иконки сообщений</string>
 	<string name="display_post_icons__summary">Иконки доступны в некоторых разделах</string>
 	<string name="do_nothing">Ничего не делать</string>

--- a/lang/values-ru/strings.xml
+++ b/lang/values-ru/strings.xml
@@ -574,5 +574,6 @@
 	<string name="favorites_show_all">Показать все</string>
 	<string name="favorites_hide_deleted">Скрыть удаленные</string>
 	<string name="favorites_show_deleted">Показать удаленные</string>
+	<string name="hidden_posts_count__format">Скрыто постов: %1$d</string>
 
 </resources>

--- a/lang/values/strings.xml
+++ b/lang/values/strings.xml
@@ -556,5 +556,5 @@
 	<string name="favorites_show_all">Show all</string>
 	<string name="favorites_hide_deleted">Hide deleted</string>
 	<string name="favorites_show_deleted">Show deleted</string>
-
+	<string name="hidden_posts_count__format">Hidden posts: %1$d</string>
 </resources>

--- a/lang/values/strings.xml
+++ b/lang/values/strings.xml
@@ -120,6 +120,8 @@
 	<string name="details">Details</string>
 	<string name="disabled">Disabled</string>
 	<string name="display_hidden_threads">Display hidden threads</string>
+	<string name="display_hidden_posts">Display hidden posts</string>
+	<string name="display_hidden_posts__summary">Deactivating the feature completely removes the display of posts that was autohided</string>
 	<string name="display_post_icons">Display post icons</string>
 	<string name="display_post_icons__summary">Post icons may be available on some boards</string>
 	<string name="do_nothing">Do nothing</string>

--- a/lang/values/strings.xml
+++ b/lang/values/strings.xml
@@ -121,7 +121,7 @@
 	<string name="disabled">Disabled</string>
 	<string name="display_hidden_threads">Display hidden threads</string>
 	<string name="display_hidden_posts">Display hidden posts</string>
-	<string name="display_hidden_posts__summary">Deactivating the feature completely removes the display of posts that was autohided</string>
+	<string name="display_hidden_posts__summary">Deactivating the feature completely removes the display of posts that was hidden</string>
 	<string name="display_post_icons">Display post icons</string>
 	<string name="display_post_icons__summary">Post icons may be available on some boards</string>
 	<string name="do_nothing">Do nothing</string>

--- a/src/com/mishiranu/dashchan/content/Preferences.java
+++ b/src/com/mishiranu/dashchan/content/Preferences.java
@@ -1468,7 +1468,7 @@ public class Preferences {
 	public static final String KEY_DISPLAY_HIDDEN_POSTS = "display_hidden_posts";
 	public static final boolean DEFAULT_DISPLAY_HIDDEN_POSTS = true;
 
-	public static boolean isDefaultDisplayHiddenPostsEnabled(){
+	public static boolean isDisplayHiddenPostsEnabled(){
 		return PREFERENCES.getBoolean(KEY_DISPLAY_HIDDEN_POSTS, DEFAULT_DISPLAY_HIDDEN_POSTS);
 	}
 

--- a/src/com/mishiranu/dashchan/content/Preferences.java
+++ b/src/com/mishiranu/dashchan/content/Preferences.java
@@ -1465,6 +1465,13 @@ public class Preferences {
 		return PREFERENCES.getBoolean(KEY_SWIPE_TO_HIDE_THREAD, DEFAULT_SWIPE_TO_HIDE_THREAD);
 	}
 
+	public static final String KEY_DISPLAY_HIDDEN_POSTS = "display_hidden_posts";
+	public static final boolean DEFAULT_DISPLAY_HIDDEN_POSTS = true;
+
+	public static boolean isDefaultDisplayHiddenPostsEnabled(){
+		return PREFERENCES.getBoolean(KEY_DISPLAY_HIDDEN_POSTS, DEFAULT_DISPLAY_HIDDEN_POSTS);
+	}
+
 	public static final String KEY_FIREWALL_RESOLUTION_METHOD = "firewall_resolution_method";
 	public static final FirewallResolutionMethod DEFAULT_FIREWALL_RESOLUTION_METHOD = FirewallResolutionMethod.MANUAL;
 

--- a/src/com/mishiranu/dashchan/content/model/PostItem.java
+++ b/src/com/mishiranu/dashchan/content/model/PostItem.java
@@ -75,6 +75,18 @@ public class PostItem implements AttachmentItem.Master, ChanMarkup.MarkupExtra, 
 			public int size() {
 				return map.size();
 			}
+
+			public int count(HideState state) {
+				int count = 0;
+				boolean seek = false;
+				if (state == HIDDEN)
+					seek = true;
+				for (Boolean value : map.values()) {
+					if (seek == value)
+						count++;
+				}
+				return count;
+			}
 		}
 	}
 

--- a/src/com/mishiranu/dashchan/content/model/PostItem.java
+++ b/src/com/mishiranu/dashchan/content/model/PostItem.java
@@ -386,6 +386,8 @@ public class PostItem implements AttachmentItem.Master, ChanMarkup.MarkupExtra, 
 		return post.isPosterBanned();
 	}
 
+	public boolean isHidden() { return hideState.hidden; }
+
 	public enum BumpLimitState {NOT_REACHED, REACHED, NEED_COUNT}
 
 	public BumpLimitState getBumpLimitReachedState(Chan chan, int postsCount) {

--- a/src/com/mishiranu/dashchan/ui/navigator/adapter/PostsAdapter.java
+++ b/src/com/mishiranu/dashchan/ui/navigator/adapter/PostsAdapter.java
@@ -329,14 +329,10 @@ public class PostsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder>
 		if (wasHidden) {
 			recyclerView.post(
 					() -> {
-						int referencePosition = 0;
-						boolean foundReference = false;
 						for (PostNumber referenceTo : post.getReferencesTo()) {
 							PostItem referenced = postItemsMap.get(referenceTo);
 							if (referenced != null) {
 								referenced.removeReferenceFrom(post.getPostNumber());
-								referencePosition = positionOfPostNumber(referenced.getPostNumber());
-								foundReference = true;
 							}
 						}
 						gallerySet.remove(post.getPostNumber());
@@ -345,8 +341,6 @@ public class PostsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder>
 						postNumbers.addAll(postItemsMap.keySet());
 						Collections.sort(postNumbers);
 						notifyDataSetChanged();
-						if (foundReference)
-							notifyItemChanged(referencePosition);
 					}
 			);
 		}

--- a/src/com/mishiranu/dashchan/ui/navigator/adapter/PostsAdapter.java
+++ b/src/com/mishiranu/dashchan/ui/navigator/adapter/PostsAdapter.java
@@ -116,7 +116,7 @@ public class PostsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder>
 		return postNumbers.size();
 	}
 
-	public int getHidedPostsCount() {
+	public int getHiddenPostsCount() {
 		return hiddenPosts.count(PostItem.HideState.HIDDEN);
 	}
 

--- a/src/com/mishiranu/dashchan/ui/navigator/adapter/PostsAdapter.java
+++ b/src/com/mishiranu/dashchan/ui/navigator/adapter/PostsAdapter.java
@@ -65,9 +65,11 @@ public class PostsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder>
 	private final UiManager.DemandSet demandSet = new UiManager.DemandSet();
 	private final GalleryItem.Set gallerySet = new GalleryItem.Set(true);
 	private final CommentTextView.RecyclerKeeper recyclerKeeper;
+	private final RecyclerView recyclerView;
 
 	private final ArrayList<PostNumber> postNumbers = new ArrayList<>();
 	private final Map<PostNumber, PostItem> postItemsMap;
+	public final PostItem.HideState.Map<PostNumber> hiddenPosts;
 	private final HashSet<PostNumber> selected = new HashSet<>();
 
 	private int bumpLimitOrdinalIndex = PostItem.ORDINAL_INDEX_NONE;
@@ -75,14 +77,16 @@ public class PostsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder>
 
 	public PostsAdapter(Callback callback, String chanName, UiManager uiManager, Replyable replyable,
 			UiManager.PostStateProvider postStateProvider, FragmentManager fragmentManager, RecyclerView recyclerView,
-			Map<PostNumber, PostItem> postItemsMap) {
+			Map<PostNumber, PostItem> postItemsMap, PostItem.HideState.Map<PostNumber> hiddenPosts) {
 		this.uiManager = uiManager;
 		configurationSet = new UiManager.ConfigurationSet(chanName, replyable, this, postStateProvider,
 				gallerySet, fragmentManager, uiManager.dialog().createStackInstance(), this, callback,
 				true, false, true, true, true, null);
 		recyclerKeeper = new CommentTextView.RecyclerKeeper(recyclerView);
+		this.recyclerView = recyclerView;
 		super.registerAdapterDataObserver(recyclerKeeper);
 		this.postItemsMap = postItemsMap;
+		this.hiddenPosts = hiddenPosts;
 		postNumbers.addAll(postItemsMap.keySet());
 		Collections.sort(postNumbers);
 		preloadPosts(0);
@@ -110,6 +114,10 @@ public class PostsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder>
 	@Override
 	public int getItemCount() {
 		return postNumbers.size();
+	}
+
+	public int getHidedPostsCount() {
+		return hiddenPosts.count(PostItem.HideState.HIDDEN);
 	}
 
 	@Override
@@ -304,6 +312,44 @@ public class PostsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder>
 
 	public void reloadAttachment(int position, AttachmentItem attachmentItem) {
 		notifyItemChanged(position, attachmentItem);
+	}
+
+	public void removeHiddenPost(PostItem post) {
+		int position = positionOfPostNumber(post.getPostNumber());
+		Iterator<PostItem> iterator = postItemsMap.values().iterator();
+		boolean wasHidden = false;
+		while (iterator.hasNext()) {
+			PostItem postItem = iterator.next();
+			if (post.getPostNumber().equals(postItem.getPostNumber()) && position != 0) {
+				wasHidden = true;
+				cancelPreloading();
+				break;
+			}
+		}
+		if (wasHidden) {
+			recyclerView.post(
+					() -> {
+						int referencePosition = 0;
+						boolean foundReference = false;
+						for (PostNumber referenceTo : post.getReferencesTo()) {
+							PostItem referenced = postItemsMap.get(referenceTo);
+							if (referenced != null) {
+								referenced.removeReferenceFrom(post.getPostNumber());
+								referencePosition = positionOfPostNumber(referenced.getPostNumber());
+								foundReference = true;
+							}
+						}
+						gallerySet.remove(post.getPostNumber());
+						postItemsMap.remove(post.getPostNumber());
+						postNumbers.clear();
+						postNumbers.addAll(postItemsMap.keySet());
+						Collections.sort(postNumbers);
+						notifyDataSetChanged();
+						if (foundReference)
+							notifyItemChanged(referencePosition);
+					}
+			);
+		}
 	}
 
 	public boolean clearDeletedPosts() {

--- a/src/com/mishiranu/dashchan/ui/navigator/page/PostsPage.java
+++ b/src/com/mishiranu/dashchan/ui/navigator/page/PostsPage.java
@@ -298,6 +298,11 @@ public class PostsPage extends ListPage implements PostsAdapter.Callback, Favori
 						postItem.setHidden(PostItem.HideState.SHOWN, null);
 					}
 				}
+				if (!Preferences.isDisplayHiddenPostsEnabled() && postItem.isHidden()) {
+					getAdapter().removeHiddenPost(postItem);
+					setPostHideState(postItem, postItem.getHideState());
+					notifyTitleChanged();
+				}
 			}
 			return postItem.getHideState().hidden;
 		}
@@ -359,7 +364,8 @@ public class PostsPage extends ListPage implements PostsAdapter.Callback, Favori
 			return board.allowPosting;
 		};
 		PostsAdapter adapter = new PostsAdapter(this, page.chanName, uiManager,
-				replyable, postStateProvider, getFragmentManager(), recyclerView, retainableExtra.postItems);
+				replyable, postStateProvider, getFragmentManager(),
+				recyclerView, retainableExtra.postItems, retainableExtra.hiddenPosts);
 		recyclerView.setAdapter(adapter);
 		recyclerView.addItemDecoration(new DividerItemDecoration(recyclerView.getContext(),
 				(c, position) -> adapter.configureDivider(c, position).horizontal(dividerPadding, dividerPadding)));
@@ -582,6 +588,17 @@ public class PostsPage extends ListPage implements PostsAdapter.Callback, Favori
 			Page page = getPage();
 			return StringUtils.formatThreadTitle(page.chanName, page.boardName, page.threadNumber);
 		}
+	}
+
+	@Override
+	public Pair<String, String> obtainTitleSubtitle() {
+		String subtitle = null;
+		if (!Preferences.isDisplayHiddenPostsEnabled()) {
+			int hidden = getAdapter().getHidedPostsCount();
+			if (hidden > 0)
+				subtitle = getString(R.string.hidden_posts_count__format, hidden);
+		}
+		return new Pair<>(this.obtainTitle(), subtitle);
 	}
 
 	@Override
@@ -1832,6 +1849,11 @@ public class PostsPage extends ListPage implements PostsAdapter.Callback, Favori
 			case PERFORM_SWITCH_HIDE: {
 				setPostHideState(postItem, !postItem.getHideState().hidden
 						? PostItem.HideState.HIDDEN : PostItem.HideState.SHOWN);
+				if (postItem.getHideState() == PostItem.HideState.HIDDEN) {
+					if (!Preferences.isDisplayHiddenPostsEnabled())
+						getAdapter().removeHiddenPost(postItem);
+				}
+				notifyTitleChanged();
 				getUiManager().sendPostItemMessage(postItem, UiManager.Message.POST_INVALIDATE_ALL_VIEWS);
 				break;
 			}
@@ -1865,6 +1887,13 @@ public class PostsPage extends ListPage implements PostsAdapter.Callback, Favori
 					encodeAndStoreThreadExtra();
 				} else if (result == HidePerformer.AddResult.EXISTS && !postItem.getHideState().hidden) {
 					setPostHideState(postItem, PostItem.HideState.UNDEFINED);
+					if (message == UiManager.Message.PERFORM_HIDE_REPLIES) {
+						for (PostNumber postNumber : postItem.getReferencesFrom()) {
+							PostItem post = getAdapter().findPostItem(postNumber);
+							if (post != null)
+								setPostHideState(post, PostItem.HideState.UNDEFINED);
+						}
+					}
 					notifyAllAdaptersChanged();
 				}
 				adapter.preloadPosts(((LinearLayoutManager) recyclerView.getLayoutManager())

--- a/src/com/mishiranu/dashchan/ui/navigator/page/PostsPage.java
+++ b/src/com/mishiranu/dashchan/ui/navigator/page/PostsPage.java
@@ -594,7 +594,7 @@ public class PostsPage extends ListPage implements PostsAdapter.Callback, Favori
 	public Pair<String, String> obtainTitleSubtitle() {
 		String subtitle = null;
 		if (!Preferences.isDisplayHiddenPostsEnabled()) {
-			int hidden = getAdapter().getHidedPostsCount();
+			int hidden = getAdapter().getHiddenPostsCount();
 			if (hidden > 0)
 				subtitle = getString(R.string.hidden_posts_count__format, hidden);
 		}

--- a/src/com/mishiranu/dashchan/ui/preference/InterfaceFragment.java
+++ b/src/com/mishiranu/dashchan/ui/preference/InterfaceFragment.java
@@ -86,6 +86,8 @@ public class InterfaceFragment extends PreferenceFragment {
 				R.string.display_post_icons, R.string.display_post_icons__summary);
 		addCheck(true, Preferences.KEY_SHOW_IMPORTANT_POSTS_ON_FASTSCROLL_BAR, Preferences.DEFAULT_SHOW_IMPORTANT_POSTS_ON_FASTSCROLL_BAR, R.string.show_important_posts_on_fastscroll_bar, 0);
 		addDependency(Preferences.KEY_SHOW_IMPORTANT_POSTS_ON_FASTSCROLL_BAR, Preferences.KEY_ACTIVE_SCROLLBAR, true);
+		addCheck(true, Preferences.KEY_DISPLAY_HIDDEN_POSTS, Preferences.DEFAULT_DISPLAY_HIDDEN_POSTS,
+				R.string.display_hidden_posts, R.string.display_hidden_posts__summary);
 
 		addHeader(R.string.submission_form);
 		addCheck(true, Preferences.KEY_HIDE_PERSONAL_DATA,


### PR DESCRIPTION
Completed the development of a feature that should fully hide posts that were hidden using autohide rules or manually by the user.

To prevent IOOBE and other exceptions, all data manipulation is done in the UI thread. If there are too many hidden posts when the thread is first opened, some lags are possible, because the loading and collection of the template seems to be performed by the client on the fly.

Fixed accidentally found bug with hiding

Closes #62, fix #84 