### PR TITLE
Fix gallery crash after process death

### DIFF
--- a/src/com/mishiranu/dashchan/ui/gallery/GalleryOverlay.java
+++ b/src/com/mishiranu/dashchan/ui/gallery/GalleryOverlay.java
@@ -131,7 +131,12 @@ public class GalleryOverlay extends DialogFragment implements GalleryDialog.Call
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
-		setRetainInstance(true);
+		boolean restoringAfterProcessDeath = savedInstanceState != null;
+		if (restoringAfterProcessDeath) {
+			dismiss();
+		} else {
+			setRetainInstance(true);
+		}
 	}
 
 	@NonNull

--- a/src/com/mishiranu/dashchan/ui/gallery/GalleryOverlay.java
+++ b/src/com/mishiranu/dashchan/ui/gallery/GalleryOverlay.java
@@ -378,15 +378,17 @@ public class GalleryOverlay extends DialogFragment implements GalleryDialog.Call
 
 	@Override
 	public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
-		menu.add(0, R.id.menu_save, 0, R.string.save)
-				.setIcon(ResourceUtils.getActionBarIcon(instance.context, R.attr.iconActionSave))
-				.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS);
-		menu.add(0, R.id.menu_refresh, 0, R.string.refresh)
-				.setIcon(ResourceUtils.getActionBarIcon(instance.context, R.attr.iconActionRefresh))
-				.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS);
-		menu.add(0, R.id.menu_select, 0, R.string.select)
-				.setIcon(ResourceUtils.getActionBarIcon(instance.context, R.attr.iconActionSelect))
-				.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS);
+		if (instance != null) {
+			menu.add(0, R.id.menu_save, 0, R.string.save)
+					.setIcon(ResourceUtils.getActionBarIcon(instance.context, R.attr.iconActionSave))
+					.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS);
+			menu.add(0, R.id.menu_refresh, 0, R.string.refresh)
+					.setIcon(ResourceUtils.getActionBarIcon(instance.context, R.attr.iconActionRefresh))
+					.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS);
+			menu.add(0, R.id.menu_select, 0, R.string.select)
+					.setIcon(ResourceUtils.getActionBarIcon(instance.context, R.attr.iconActionSelect))
+					.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Fixes #81

After fixing #81, i discovered that the gallery will be empty after process death even if a thread has gallery items. So i added the fix that closes the gallery if it is restored after process death. We can remove it later when the proper restoration of the gallery state is developed.