### PR TITLE
Fix themes and updates urls

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,9 +48,9 @@ android {
 
 		buildConfigField 'String', 'VERSION_DATE', '"' + versions[0].date + '"'
 		buildConfigField 'String', 'URI_UPDATES', '"//raw.githubusercontent.com/' +
-				'TrixiEther/DashchanFork/experemental/update/data.json"'
+				'TrixiEther/DashchanFork/experimental/update/data.json"'
 		buildConfigField 'String', 'URI_THEMES', '"//raw.githubusercontent.com/' +
-				'TrixiEther/DashchanFork/experemental/update/themes.json"'
+				'TrixiEther/DashchanFork/experimental/update/themes.json"'
 		buildConfigField 'String', 'GITHUB_URI_METADATA', '"//github.com/TrixiEther/DashchanFork"'
 		buildConfigField 'String', 'GITHUB_PATH_METADATA', '"metadata"'
 	}


### PR DESCRIPTION
Themes and updates urls are now invalid because the name of "experimental" branch has changed. Here's the fix just in case.