### PR TITLE
Fix crash when updating important posts scroll bar data and a thread has deleted posts

### DIFF
--- a/src/com/mishiranu/dashchan/ui/navigator/page/PostsPage.java
+++ b/src/com/mishiranu/dashchan/ui/navigator/page/PostsPage.java
@@ -1761,7 +1761,10 @@ public class PostsPage extends ListPage implements PostsAdapter.Callback, Favori
 
 			for (PostNumber userPostNumber : userPosts) {
 				int userPostPosition = adapter.positionOfPostNumber(userPostNumber);
-				boolean showUserPostOnScrollBar = userPostPosition >= 0 && !postStateProvider.isHiddenResolve(adapter.getItem(userPostPosition));
+				if (userPostPosition < 0) {
+					continue;
+				}
+				boolean showUserPostOnScrollBar = !postStateProvider.isHiddenResolve(adapter.getItem(userPostPosition));
 				if (showUserPostOnScrollBar) {
 					userPostsPositions.add(userPostPosition);
 				}


### PR DESCRIPTION
Found out that the app may crash when a  thread has deleted items and marks on the scrollbar are enabled.