### PR TITLE
Fix possible crash when cancel all downloads

### DIFF
--- a/src/com/mishiranu/dashchan/content/service/DownloadService.java
+++ b/src/com/mishiranu/dashchan/content/service/DownloadService.java
@@ -311,12 +311,12 @@ public class DownloadService extends BaseService implements ReadFileTask.Callbac
 
 	private void startNextTask() {
 		if (activeTask == null && !queuedTasks.isEmpty()) {
+			Iterator<TaskData> iterator = queuedTasks.values().iterator();
+			TaskData taskData = iterator.next();
+			iterator.remove();
 			SINGLE_THREAD_EXECUTOR.execute(() -> {
-				Iterator<TaskData> iterator = queuedTasks.values().iterator();
-				TaskData taskData = iterator.next();
 				DataFile taskDataFile = getDataFile(taskData);
 				activeTaskDataFile = taskDataFile;
-				iterator.remove();
 				if (taskData.input != null) {
 					boolean success = false;
 					try (InputStream input = taskData.input; OutputStream output = taskDataFile.openOutputStream()) {


### PR DESCRIPTION
When a user downloads files and presses "cancel all" button in the notification, there is a chance that the app will crash with ConcurrentModificationException because one thread (main) is iterating through tasks in "cleanup" method while another thread (executor) modifies collection in "startNextTask" method. Fix this by moving "iterator.remove" call to the main thread.