### PR TITLE
Add ability to copy images to clipboard

### DIFF
--- a/lang/values-ru/strings.xml
+++ b/lang/values-ru/strings.xml
@@ -97,8 +97,10 @@
 	<string name="context_menu">Контекстное меню</string>
 	<string name="context_menu_description__sentence">Используйте долгое нажатие для отображения
 		контекстного меню.</string>
+	<string name="copied_to_clipboard">Скопировано в буфер обмена</string>
 	<string name="copy">Копировать</string>
 	<string name="copy_email">Копировать email</string>
+	<string name="copy_image">Копировать изображение</string>
 	<string name="copy_link">Копировать ссылку</string>
 	<string name="copy_markup">Копировать разметку</string>
 	<string name="copy_text">Копировать текст</string>

--- a/lang/values/strings.xml
+++ b/lang/values/strings.xml
@@ -97,8 +97,10 @@
 	<string name="contents">Contents</string>
 	<string name="context_menu">Context menu</string>
 	<string name="context_menu_description__sentence">Use long tap to display context menu.</string>
+	<string name="copied_to_clipboard">Copied to clipboard</string>
 	<string name="copy">Copy</string>
 	<string name="copy_email">Copy email</string>
+	<string name="copy_image">Copy image</string>
 	<string name="copy_link">Copy link</string>
 	<string name="copy_markup">Copy markup</string>
 	<string name="copy_text">Copy text</string>

--- a/src/com/mishiranu/dashchan/C.java
+++ b/src/com/mishiranu/dashchan/C.java
@@ -22,6 +22,7 @@ public class C {
 	public static final boolean API_Q = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q;
 	public static final boolean API_R = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R;
 	public static final boolean API_S = Build.VERSION.SDK_INT >= 31;
+	public static final boolean API_S_V2 = Build.VERSION.SDK_INT >= 32;
 
 	public static final boolean USE_SAF = API_MARSHMALLOW;
 

--- a/src/com/mishiranu/dashchan/content/FileUriClipboard.java
+++ b/src/com/mishiranu/dashchan/content/FileUriClipboard.java
@@ -1,0 +1,37 @@
+package com.mishiranu.dashchan.content;
+
+import android.content.ClipData;
+import android.content.ClipboardManager;
+import android.content.ContentResolver;
+import android.content.Context;
+import android.net.Uri;
+
+import com.mishiranu.dashchan.C;
+import com.mishiranu.dashchan.R;
+import com.mishiranu.dashchan.widget.ClickableToast;
+
+import java.io.File;
+
+public final class FileUriClipboard {
+
+	private FileUriClipboard() {
+	}
+
+	public static void copyFileUriToClipboard(File file, String originalFileName) {
+		Uri fileUri = CacheManager.getInstance().prepareFileForClipboard(file, originalFileName);
+		if (fileUri == null) {
+			ClickableToast.show(R.string.cache_is_unavailable);
+			return;
+		}
+		Context context = MainApplication.getInstance();
+		ClipboardManager clipboard = (ClipboardManager) context.getSystemService(Context.CLIPBOARD_SERVICE);
+		ContentResolver contentResolver = context.getContentResolver();
+		ClipData clip = ClipData.newUri(contentResolver, originalFileName, fileUri);
+		clipboard.setPrimaryClip(clip);
+		if (!C.API_S_V2) {
+			ClickableToast.show(R.string.copied_to_clipboard);
+		}
+	}
+
+}
+


### PR DESCRIPTION
To copy an image to the clipboard, a user needs to open an image in the gallery, and when the image is downloaded to the cache, "Copy image" option will be available in the menu. After copying the image can be pasted in other applications.

I also refactored FileProvider class because there was a lot of duplicated code after i added clipboard logic. I made a separate commit for this, so you can not include it if you think it is not necessary now.