### PR TITLE
TrixiEther | Attachment features was broken

### DIFF
--- a/src/com/mishiranu/dashchan/ui/posting/dialog/AttachmentOptionsDialog.java
+++ b/src/com/mishiranu/dashchan/ui/posting/dialog/AttachmentOptionsDialog.java
@@ -166,15 +166,16 @@ public class AttachmentOptionsDialog extends DialogFragment implements AdapterVi
 			listView.setDividerHeight(0);
 		}
 		ItemsAdapter adapter = new ItemsAdapter(activity, resId, items);
+
+		ViewGroup nameExtensionLayout = (ViewGroup) LayoutInflater.from(activity).inflate(R.layout.dialog_filename, listView, false);
+		listView.addFooterView(nameExtensionLayout);
 		listView.setAdapter(adapter);
+
 		for (int i = 0; i < optionItems.size(); i++) {
 			listView.setItemChecked(i, optionItems.get(i).checked);
 		}
 		listView.setOnItemClickListener(this);
 
-		ViewGroup nameExtensionLayout = (ViewGroup) LayoutInflater.from(activity).inflate(R.layout.dialog_filename, listView, false);
-		listView.addFooterView(nameExtensionLayout);
-		listView.setAdapter(adapter);
 		filenameEditText = nameExtensionLayout.findViewById(R.id.filename);
 		filenameEditText.setText(StringUtils.removeFileExtension(holder.newname));
 		InputFilter filter = (source, start, end, dest, dstart, dend) -> {
@@ -299,7 +300,7 @@ public class AttachmentOptionsDialog extends DialogFragment implements AdapterVi
 		if (reencodeIndex != null) {
 			holder.reencoding = reencoding;
 			listView.setItemChecked(reencodeIndex, reencoding != null);
-			updateItemsEnabled((ItemsAdapter) listView.getAdapter(), holder);
+			updateItemsEnabled((ItemsAdapter) ((HeaderViewListAdapter) listView.getAdapter()).getWrappedAdapter(), holder);
 		}
 	}
 }


### PR DESCRIPTION
Found out that the feature with attachments was broken, probably due to the fact that the logic of working with adapters has changed a bit:

1. When user select from the prefetences, always rename the file / set a unique hash / metadata, then the feature was not applied when the file was attached to the post. I removed the extra call to setAdapter and moved the code that checks if the element is selected to another place, it worked
2. The application crashed when an attempt was made to reencode a file. Fixed