### PR TITLE
Filerename feature bugs

### DIFF
--- a/src/com/mishiranu/dashchan/ui/posting/dialog/AttachmentOptionsDialog.java
+++ b/src/com/mishiranu/dashchan/ui/posting/dialog/AttachmentOptionsDialog.java
@@ -44,6 +44,8 @@ public class AttachmentOptionsDialog extends DialogFragment implements AdapterVi
 	public static final String TAG = AttachmentOptionsDialog.class.getName();
 
 	private static final String EXTRA_ATTACHMENT_INDEX = "attachmentIndex";
+	private static final String FILENAME_BLOCKED_CHARACTERS = "\\/:*?\"<>|.";
+	private static final int FILENAME_MAX_CHARACTER_COUNT = 255;
 
 	private enum Type {UNIQUE_HASH, REMOVE_METADATA, REENCODE_IMAGE, REMOVE_FILE_NAME, SPOILER, RENAME}
 
@@ -168,6 +170,7 @@ public class AttachmentOptionsDialog extends DialogFragment implements AdapterVi
 		ItemsAdapter adapter = new ItemsAdapter(activity, resId, items);
 
 		ViewGroup nameExtensionLayout = (ViewGroup) LayoutInflater.from(activity).inflate(R.layout.dialog_filename, listView, false);
+		nameExtensionLayout.setOnClickListener(null);
 		listView.addFooterView(nameExtensionLayout);
 		listView.setAdapter(adapter);
 
@@ -180,7 +183,7 @@ public class AttachmentOptionsDialog extends DialogFragment implements AdapterVi
 		filenameEditText.setText(StringUtils.removeFileExtension(holder.newname));
 		InputFilter filter = (source, start, end, dest, dstart, dend) -> {
 			for (int i = start; i < end; i++) {
-				if (!Character.isLetterOrDigit(source.charAt(i)) || Character.isSpaceChar(source.charAt(i))) {
+				if (FILENAME_BLOCKED_CHARACTERS.contains(Character.toString(source.charAt(i)))) {
 					return "";
 				}
 			}
@@ -194,11 +197,15 @@ public class AttachmentOptionsDialog extends DialogFragment implements AdapterVi
 
 			@Override
 			public void onTextChanged(CharSequence s, int start, int before, int count) {
-				holder.newname = s.toString() + "." + StringUtils.getFileExtension(holder.name);
+				if (s.length() > FILENAME_MAX_CHARACTER_COUNT) {
+					CharSequence filename = s.subSequence(0, FILENAME_MAX_CHARACTER_COUNT);
+					filenameEditText.setText(filename);
+				}
 			}
 
 			@Override
 			public void afterTextChanged(Editable s) {
+				holder.newname = s.toString() + "." + StringUtils.getFileExtension(holder.name);
 			}
 		});
 		extensionTextView = nameExtensionLayout.findViewById(R.id.extension);

--- a/src/com/mishiranu/dashchan/ui/posting/dialog/AttachmentOptionsDialog.java
+++ b/src/com/mishiranu/dashchan/ui/posting/dialog/AttachmentOptionsDialog.java
@@ -33,6 +33,7 @@ import com.mishiranu.dashchan.content.storage.DraftsStorage;
 import com.mishiranu.dashchan.graphics.TransparentTileDrawable;
 import com.mishiranu.dashchan.ui.posting.AttachmentHolder;
 import com.mishiranu.dashchan.ui.posting.PostingDialogCallback;
+import com.mishiranu.dashchan.util.FilenameUtils;
 import com.mishiranu.dashchan.util.GraphicsUtils;
 import com.mishiranu.dashchan.util.ResourceUtils;
 import com.mishiranu.dashchan.widget.MaterialButton;
@@ -183,13 +184,16 @@ public class AttachmentOptionsDialog extends DialogFragment implements AdapterVi
 		filenameEditText.setText(StringUtils.removeFileExtension(holder.newname));
 		InputFilter filter = (source, start, end, dest, dstart, dend) -> {
 			for (int i = start; i < end; i++) {
-				if (FILENAME_BLOCKED_CHARACTERS.contains(Character.toString(source.charAt(i)))) {
+				if (!FilenameUtils.isValidCharacter(source.charAt(i))) {
 					return "";
 				}
 			}
 			return null;
 		};
-		filenameEditText.setFilters(new InputFilter[]{filter});
+		filenameEditText.setFilters(new InputFilter[]{
+				filter,
+				new InputFilter.LengthFilter(FilenameUtils.getFilenameMaxCharacterCount())
+		});
 		filenameEditText.addTextChangedListener(new TextWatcher() {
 			@Override
 			public void beforeTextChanged(CharSequence s, int start, int count, int after) {
@@ -197,10 +201,6 @@ public class AttachmentOptionsDialog extends DialogFragment implements AdapterVi
 
 			@Override
 			public void onTextChanged(CharSequence s, int start, int before, int count) {
-				if (s.length() > FILENAME_MAX_CHARACTER_COUNT) {
-					CharSequence filename = s.subSequence(0, FILENAME_MAX_CHARACTER_COUNT);
-					filenameEditText.setText(filename);
-				}
 			}
 
 			@Override

--- a/src/com/mishiranu/dashchan/ui/preference/MediaFragment.java
+++ b/src/com/mishiranu/dashchan/ui/preference/MediaFragment.java
@@ -4,6 +4,7 @@ import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
+import android.text.InputFilter;
 import android.text.InputType;
 import android.text.SpannableStringBuilder;
 import android.text.style.ForegroundColorSpan;
@@ -29,6 +30,7 @@ import com.mishiranu.dashchan.ui.preference.core.EditPreference;
 import com.mishiranu.dashchan.ui.preference.core.Preference;
 import com.mishiranu.dashchan.ui.preference.core.PreferenceFragment;
 import com.mishiranu.dashchan.util.ConcurrentUtils;
+import com.mishiranu.dashchan.util.FilenameUtils;
 import com.mishiranu.dashchan.util.IOUtils;
 import com.mishiranu.dashchan.util.ResourceUtils;
 import com.mishiranu.dashchan.util.SharedPreferences;
@@ -76,7 +78,16 @@ public class MediaFragment extends PreferenceFragment implements FragmentHandler
 				R.string.always_rename_files, 0);
 		addDependency(Preferences.KEY_ALWAYS_RENAME_FILENAME, Preferences.KEY_ALWAYS_REMOVE_FILENAME, false);
 		addEdit(Preferences.KEY_FILE_NEWNAME, Preferences.DEFAULT_FILE_NEWNAME, R.string.new_filename,
-				Preferences.DEFAULT_FILE_NEWNAME, InputType.TYPE_CLASS_TEXT);
+				Preferences.DEFAULT_FILE_NEWNAME, InputType.TYPE_CLASS_TEXT)
+				.addFilter((source, start, end, dest, dstart, dend) -> {
+					for (int i = start; i < end; i++) {
+						if (!FilenameUtils.isValidCharacter(source.charAt(i))) {
+							return "";
+						}
+					}
+					return null;
+				})
+				.addFilter(new InputFilter.LengthFilter(FilenameUtils.getFilenameMaxCharacterCount()));
 		addDependency(Preferences.KEY_FILE_NEWNAME, Preferences.KEY_ALWAYS_REMOVE_FILENAME, false);
 
 		addHeader(R.string.downloads);

--- a/src/com/mishiranu/dashchan/ui/preference/core/EditPreference.java
+++ b/src/com/mishiranu/dashchan/ui/preference/core/EditPreference.java
@@ -15,16 +15,19 @@ import com.mishiranu.dashchan.util.FlagUtils;
 import com.mishiranu.dashchan.util.SharedPreferences;
 import com.mishiranu.dashchan.util.ViewUtils;
 import com.mishiranu.dashchan.widget.SafePasteEditText;
+import java.util.ArrayList;
 
 public class EditPreference extends DialogPreference<String> {
 	public final CharSequence hint;
 	public final int inputType;
+	public ArrayList<InputFilter> customFilters;
 
 	public EditPreference(Context context, String key, String defaultValue,
 			CharSequence title, SummaryProvider<String> summaryProvider, CharSequence hint, int inputType) {
 		super(context, key, defaultValue, title, summaryProvider);
 		this.hint = hint;
 		this.inputType = inputType;
+		customFilters = new ArrayList<>();
 	}
 
 	@Override
@@ -49,7 +52,7 @@ public class EditPreference extends DialogPreference<String> {
 		Pair<View, LinearLayout> pair = createDialogLayout(builder.getContext());
 		SafePasteEditText editText = new SafePasteEditText(pair.second.getContext());
 		editText.setId(android.R.id.edit);
-		configureEdit(editText, hint, inputType, getValue());
+		configureEdit(editText, hint, inputType, getValue(), customFilters);
 		editText.requestFocus();
 		pair.second.addView(editText, LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT);
 		return super.configureDialog(savedInstanceState, builder).setView(pair.first)
@@ -58,6 +61,10 @@ public class EditPreference extends DialogPreference<String> {
 	}
 
 	public static void configureEdit(EditText editText, CharSequence hint, int inputType, CharSequence text) {
+		configureEdit(editText, hint, inputType, text, null);
+	}
+
+	public static void configureEdit(EditText editText, CharSequence hint, int inputType, CharSequence text, ArrayList<InputFilter> filters) {
 		editText.setHint(hint);
 		boolean visiblePassword = FlagUtils.get(inputType, InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD);
 		inputType = FlagUtils.set(inputType, InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD, false);
@@ -68,8 +75,20 @@ public class EditPreference extends DialogPreference<String> {
 		if (FlagUtils.get(inputType, InputType.TYPE_CLASS_NUMBER)) {
 			editText.setFilters(new InputFilter[] {new InputFilter
 					.LengthFilter(Integer.toString(Integer.MAX_VALUE).length() - 1)});
+		} else if (filters != null && filters.size() > 0) {
+			InputFilter[] filtersArray = new InputFilter[filters.size()];
+			for (int i =0; i < filters.size(); i++)
+				filtersArray[i] = filters.get(i);
+			editText.setFilters(filtersArray);
 		}
 		editText.setText(text);
 		editText.setSelection(editText.getText().length());
 	}
+
+	public EditPreference addFilter(InputFilter filter) {
+		if (filter != null)
+			this.customFilters.add(filter);
+		return this;
+	}
+
 }

--- a/src/com/mishiranu/dashchan/util/FilenameUtils.java
+++ b/src/com/mishiranu/dashchan/util/FilenameUtils.java
@@ -1,0 +1,20 @@
+package com.mishiranu.dashchan.util;
+
+public class FilenameUtils {
+
+    private static final String FILENAME_BLOCKED_CHARACTERS = "\\/:*?\"<>|.";
+    private static final int FILENAME_MAX_CHARACTER_COUNT = 255;
+
+    public static boolean isValidCharacter(char ch) {
+        return !FILENAME_BLOCKED_CHARACTERS.contains(Character.toString(ch));
+    }
+
+    public static String getFilenameBlockedCharacters() {
+        return FILENAME_BLOCKED_CHARACTERS;
+    }
+
+    public static int getFilenameMaxCharacterCount() {
+        return FILENAME_MAX_CHARACTER_COUNT;
+    }
+
+}


### PR DESCRIPTION
1. Fixed #116 
2. Fixed #123 - based on Windows OS specific prohibited characters
3. Added a check for a filename size limit of 255 characters, because the previous implementation did not work