### PR TITLE
TrixiEther | Jpeg to Jpg extension naming

### DIFF
--- a/lang/values-ru/strings.xml
+++ b/lang/values-ru/strings.xml
@@ -587,4 +587,5 @@
 	<string name="always_rename_files">Всегда переименовывать файл</string>
 	<string name="new_filename">Новое имя файла</string>
 	<string name="space_after_quote">Добавлять пробел после цитирования</string>
+	<string name="rename_to_jpg">Переименовать в .jpg</string>
 </resources>

--- a/lang/values/strings.xml
+++ b/lang/values/strings.xml
@@ -569,4 +569,5 @@
 	<string name="always_rename_files">Always rename file</string>
 	<string name="new_filename">New filename</string>
 	<string name="space_after_quote">Add space after quote</string>
+	<string name="rename_to_jpg">Rename to .jpg</string>
 </resources>

--- a/src/com/mishiranu/dashchan/ui/posting/dialog/ReencodingDialog.java
+++ b/src/com/mishiranu/dashchan/ui/posting/dialog/ReencodingDialog.java
@@ -5,6 +5,7 @@ import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
+import android.widget.CheckBox;
 import android.widget.FrameLayout;
 import android.widget.LinearLayout;
 import android.widget.RadioButton;
@@ -26,10 +27,12 @@ public class ReencodingDialog extends DialogFragment implements DialogInterface.
 
 	private static final String EXTRA_QUALITY = "quality";
 	private static final String EXTRA_REDUCE = "reduce";
+	private static final int JPEG_POSITION = 0;
 
 	private RadioGroup radioGroup;
 	private ViewFactory.SeekLayoutHolder qualityLayoutHolder;
 	private ViewFactory.SeekLayoutHolder reduceLayoutHolder;
+	private CheckBox jpegToJpg;
 
 	private static final String[] OPTIONS = {GraphicsUtils.Reencoding.FORMAT_JPEG.toUpperCase(Locale.US),
 			GraphicsUtils.Reencoding.FORMAT_PNG.toUpperCase(Locale.US)};
@@ -50,6 +53,10 @@ public class ReencodingDialog extends DialogFragment implements DialogInterface.
 		int padding = getResources().getDimensionPixelSize(R.dimen.dialog_padding_view);
 		ViewUtils.setNewPadding(qualityLayoutHolder.layout, null, 0, null, padding / 2);
 		ViewUtils.setNewPadding(reduceLayoutHolder.layout, null, 0, null, null);
+		jpegToJpg = new CheckBox(context);
+		ThemeEngine.applyStyle(jpegToJpg);
+		jpegToJpg.setText(R.string.rename_to_jpg);
+		jpegToJpg.setChecked(false);
 		radioGroup = new RadioGroup(context);
 		radioGroup.setOrientation(RadioGroup.VERTICAL);
 		radioGroup.setPadding(padding, padding, padding, padding / 2);
@@ -61,7 +68,10 @@ public class ReencodingDialog extends DialogFragment implements DialogInterface.
 			radioButton.setId(IDS[i]);
 			radioGroup.addView(radioButton);
 		}
-		radioGroup.check(IDS[0]);
+		radioGroup.check(IDS[JPEG_POSITION]);
+		LinearLayout jpegToJpgLayout = new LinearLayout(context);
+		jpegToJpgLayout.setPadding(padding, 0, 0, padding / 2);
+		jpegToJpgLayout.addView(jpegToJpg);
 		LinearLayout linearLayout = new LinearLayout(context);
 		linearLayout.setOrientation(LinearLayout.VERTICAL);
 		FrameLayout qualityLayout = new FrameLayout(context);
@@ -71,6 +81,8 @@ public class ReencodingDialog extends DialogFragment implements DialogInterface.
 		reduceLayout.setId(android.R.id.text2);
 		reduceLayout.addView(reduceLayoutHolder.layout);
 		linearLayout.addView(radioGroup, LinearLayout.LayoutParams.MATCH_PARENT,
+				LinearLayout.LayoutParams.WRAP_CONTENT);
+		linearLayout.addView(jpegToJpgLayout, LinearLayout.LayoutParams.MATCH_PARENT,
 				LinearLayout.LayoutParams.WRAP_CONTENT);
 		linearLayout.addView(qualityLayout, LinearLayout.LayoutParams.MATCH_PARENT,
 				LinearLayout.LayoutParams.WRAP_CONTENT);
@@ -97,7 +109,10 @@ public class ReencodingDialog extends DialogFragment implements DialogInterface.
 		int id = radioGroup.getCheckedRadioButtonId();
 		for (int i = 0; i < IDS.length; i++) {
 			if (IDS[i] == id) {
-				format = FORMATS[i];
+				if (i == JPEG_POSITION && jpegToJpg.isChecked())
+					format = GraphicsUtils.Reencoding.FORMAT_JPEG_ALTNAME;
+				else
+					format = FORMATS[i];
 				break;
 			}
 		}
@@ -115,5 +130,6 @@ public class ReencodingDialog extends DialogFragment implements DialogInterface.
 			}
 		}
 		qualityLayoutHolder.setEnabled(allowQuality);
+		jpegToJpg.setEnabled(checkedId == IDS[JPEG_POSITION]);
 	}
 }

--- a/src/com/mishiranu/dashchan/ui/posting/dialog/ReencodingDialog.java
+++ b/src/com/mishiranu/dashchan/ui/posting/dialog/ReencodingDialog.java
@@ -5,6 +5,7 @@ import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
+import android.view.View;
 import android.widget.CheckBox;
 import android.widget.FrameLayout;
 import android.widget.LinearLayout;

--- a/src/com/mishiranu/dashchan/ui/posting/dialog/ReencodingDialog.java
+++ b/src/com/mishiranu/dashchan/ui/posting/dialog/ReencodingDialog.java
@@ -70,7 +70,7 @@ public class ReencodingDialog extends DialogFragment implements DialogInterface.
 			radioGroup.addView(radioButton);
 		}
 		radioGroup.check(IDS[JPEG_POSITION]);
-		LinearLayout jpegToJpgLayout = new LinearLayout(context);
+		FrameLayout jpegToJpgLayout = new FrameLayout(context);
 		jpegToJpgLayout.setPadding(padding, 0, 0, padding / 2);
 		jpegToJpgLayout.addView(jpegToJpg);
 		LinearLayout linearLayout = new LinearLayout(context);

--- a/src/com/mishiranu/dashchan/util/GraphicsUtils.java
+++ b/src/com/mishiranu/dashchan/util/GraphicsUtils.java
@@ -200,6 +200,7 @@ public class GraphicsUtils {
 
 	public static class Reencoding {
 		public static final String FORMAT_JPEG = "jpeg";
+		public static final String FORMAT_JPEG_ALTNAME = "jpg";
 		public static final String FORMAT_PNG = "png";
 
 		public final String format;
@@ -207,7 +208,8 @@ public class GraphicsUtils {
 		public final int reduce;
 
 		public Reencoding(String format, int quality, int reduce) {
-			this.format = FORMAT_JPEG.equals(format) || FORMAT_PNG.equals(format) ? format : FORMAT_JPEG;
+			this.format = (FORMAT_JPEG.equals(format) || FORMAT_JPEG_ALTNAME.equals(format))
+					|| FORMAT_PNG.equals(format) ? format : FORMAT_JPEG_ALTNAME.equals(format) ? format : FORMAT_JPEG;
 			this.quality = Math.max(1, Math.min(quality, 100));
 			this.reduce = Math.max(1, Math.min(reduce, 8));
 		}
@@ -277,12 +279,13 @@ public class GraphicsUtils {
 						newHeight = bitmap.getHeight();
 					}
 					boolean png = Reencoding.FORMAT_PNG.equals(reencoding.format);
+					boolean jpegToJpg = Reencoding.FORMAT_JPEG_ALTNAME.equals(reencoding.format);
 					ByteArrayOutputStream output = new ByteArrayOutputStream();
 					bitmap.compress(Reencoding.FORMAT_PNG.equals(reencoding.format) ? Bitmap.CompressFormat.PNG
 							: Bitmap.CompressFormat.JPEG, reencoding.quality, output);
 					decodedBytes = output.toByteArray();
 					int index = fileName.lastIndexOf('.');
-					newFileName = (index >= 0 ? fileName.substring(0, index) : fileName) + (png ? ".png" : ".jpeg");
+					newFileName = (index >= 0 ? fileName.substring(0, index) : fileName) + (png ? ".png" : jpegToJpg ? ".jpg" : ".jpeg");
 				} finally {
 					bitmap.recycle();
 				}


### PR DESCRIPTION
Small enhancement. Adds a checkbox to indicate when reencoding an image which of the two standard extensions to use for JPEG
I did not change the existing structure much, I think this will remain so for now the only case when the choice of format display can take place

Closes #117 