### PR TITLE
Feature: autohide with empty values

### DIFF
--- a/lang/values-ru/strings.xml
+++ b/lang/values-ru/strings.xml
@@ -31,6 +31,8 @@
 	<string name="audio_playback">Воспроизведение аудио</string>
 	<string name="audio_player">Аудиоплеер</string>
 	<string name="autohide">Автоскрытие</string>
+	<string name="autohide_empty">Скрывать посты содержащие пустые значения</string>
+	<string name="empty_values">Пустые значения</string>
 	<string name="available__plural">Доступные</string>
 	<string name="backup_data">Резервное копирование данных</string>
 	<string name="backup_data__summary">Сохранение всех настроек, избранного, истории и правил автоскрытия</string>

--- a/lang/values/strings.xml
+++ b/lang/values/strings.xml
@@ -33,6 +33,8 @@
 	<string name="audio_playback">Audio playback</string>
 	<string name="audio_player">Audio player</string>
 	<string name="autohide">Autohide</string>
+	<string name="autohide_empty">Hide posts containing empty value</string>
+	<string name="empty_values">Empty values</string>
 	<string name="available__plural">Available</string>
 	<string name="backup_data">Backup data</string>
 	<string name="backup_data__summary">Save all your settings, favorites, history, and autohide rules</string>

--- a/res/layout/dialog_autohide.xml
+++ b/res/layout/dialog_autohide.xml
@@ -80,6 +80,13 @@
 				android:textAppearance="?android:attr/textAppearanceSmall" />
 
 			<CheckBox
+				android:id="@+id/autohide_empty"
+				android:layout_width="wrap_content"
+				android:layout_height="wrap_content"
+				android:text="@string/autohide_empty"
+				android:textAppearance="?android:attr/textAppearanceSmall" />
+
+			<CheckBox
 				android:id="@+id/autohide_subject"
 				android:layout_width="wrap_content"
 				android:layout_height="wrap_content"

--- a/src/com/mishiranu/dashchan/content/HidePerformer.java
+++ b/src/com/mishiranu/dashchan/content/HidePerformer.java
@@ -130,7 +130,12 @@ public class HidePerformer {
 								if (subject == null) {
 									subject = postItem.getSubject();
 								}
-								if ((result = autohideItem.find(subject)) != null) {
+								if (autohideItem.optionEmpty) {
+									if (subject.isEmpty()) {
+										return autohideItem.getReason(AutohideStorage.AutohideItem
+												.ReasonSource.SUBJECT, null, null);
+									}
+								} else if ((result = autohideItem.find(subject)) != null) {
 									return autohideItem.getReason(AutohideStorage.AutohideItem
 											.ReasonSource.SUBJECT, comment, result);
 								}
@@ -139,38 +144,57 @@ public class HidePerformer {
 								if (comment == null) {
 									comment = postItem.getComment(chan).toString();
 								}
-								if ((result = autohideItem.find(comment)) != null) {
+								if (autohideItem.optionEmpty) {
+									if (comment.isEmpty()) {
+										return autohideItem.getReason(AutohideStorage.AutohideItem
+												.ReasonSource.COMMENT, null, null);
+									}
+								} else if ((result = autohideItem.find(comment)) != null) {
 									return autohideItem.getReason(AutohideStorage.AutohideItem
 											.ReasonSource.COMMENT, comment, result);
 								}
 							}
 							if (autohideItem.optionName) {
+								String postItemName = postItem.getFullName(chan).toString();
 								if (names == null) {
-									String name = postItem.getFullName(chan).toString();
 									List<Post.Icon> icons = postItem.getIcons();
 									if (!icons.isEmpty()) {
 										names = new ArrayList<>(1 + icons.size());
-										names.add(name);
+										names.add(postItemName);
 										for (Post.Icon icon : icons) {
 											names.add(icon.title);
 										}
 									} else {
-										names = Collections.singletonList(name);
+										names = Collections.singletonList(postItemName);
 									}
 								}
-								for (String name : names) {
-									if ((result = autohideItem.find(name)) != null) {
+								if (autohideItem.optionEmpty) {
+									if (postItemName.isEmpty()) {
 										return autohideItem.getReason(AutohideStorage.AutohideItem
-												.ReasonSource.NAME, name, result);
+												.ReasonSource.NAME, null, null);
+									}
+								} else {
+									for (String name : names) {
+										if ((result = autohideItem.find(name)) != null) {
+											return autohideItem.getReason(AutohideStorage.AutohideItem
+													.ReasonSource.NAME, name, result);
+										}
 									}
 								}
 							}
 							if (autohideItem.optionFileName && postItem.hasAttachments()) {
 								for (AttachmentItem attachmentItem : postItem.getAttachmentItems()) {
 									String originalName = StringUtils.emptyIfNull(attachmentItem.getOriginalName());
-									if ((result = autohideItem.find(originalName)) != null) {
-										return autohideItem.getReason(AutohideStorage.AutohideItem
-												.ReasonSource.FILE, originalName, result);
+									if (autohideItem.optionEmpty) {
+										if (originalName.isEmpty() || StringUtils.removeFileExtension(originalName).isEmpty()) {
+											return autohideItem.getReason(AutohideStorage.AutohideItem
+													.ReasonSource.FILE, null, null);
+										}
+									} else {
+										if ((result = autohideItem.find(originalName)) != null) {
+											return autohideItem.getReason(AutohideStorage.AutohideItem
+													.ReasonSource.FILE, originalName, result);
+										}
 									}
 								}
 							}

--- a/src/com/mishiranu/dashchan/content/storage/AutohideStorage.java
+++ b/src/com/mishiranu/dashchan/content/storage/AutohideStorage.java
@@ -25,6 +25,7 @@ public class AutohideStorage extends StorageManager.JsonOrgStorage<List<Autohide
 	private static final String KEY_OPTION_COMMENT = "optionComment";
 	private static final String KEY_OPTION_NAME = "optionName";
 	private static final String KEY_OPTION_FILE_NAME = "optionFileName";
+	private static final String KEY_OPTION_EMPTY = "optionEmpty";
 	private static final String KEY_VALUE = "value";
 
 	private static final AutohideStorage INSTANCE = new AutohideStorage();
@@ -81,9 +82,10 @@ public class AutohideStorage extends StorageManager.JsonOrgStorage<List<Autohide
 					boolean optionComment = jsonObject.optBoolean(KEY_OPTION_COMMENT);
 					boolean optionName = jsonObject.optBoolean(KEY_OPTION_NAME);
 					boolean optionFileName = jsonObject.optBoolean(KEY_OPTION_FILE_NAME);
+					boolean optionEmpty = jsonObject.optBoolean(KEY_OPTION_EMPTY);
 					String value = jsonObject.optString(KEY_VALUE, null);
 					autohideItems.add(new AutohideItem(chanNames, boardName, threadNumber, optionOriginalPost,
-							optionSage, optionSubject, optionComment, optionName, optionFileName, value));
+							optionSage, optionEmpty, optionSubject, optionComment, optionName, optionFileName, value));
 				}
 			}
 		}
@@ -110,6 +112,7 @@ public class AutohideStorage extends StorageManager.JsonOrgStorage<List<Autohide
 				putJson(jsonObject, KEY_OPTION_COMMENT, autohideItem.optionComment);
 				putJson(jsonObject, KEY_OPTION_NAME, autohideItem.optionName);
 				putJson(jsonObject, KEY_OPTION_FILE_NAME, autohideItem.optionFileName);
+				putJson(jsonObject, KEY_OPTION_EMPTY, autohideItem.optionEmpty);
 				putJson(jsonObject, KEY_VALUE, autohideItem.value);
 				jsonArray.put(jsonObject);
 			}
@@ -155,6 +158,7 @@ public class AutohideStorage extends StorageManager.JsonOrgStorage<List<Autohide
 
 		public boolean optionOriginalPost;
 		public boolean optionSage;
+		public boolean optionEmpty;
 
 		public boolean optionSubject;
 		public boolean optionComment;
@@ -171,15 +175,15 @@ public class AutohideStorage extends StorageManager.JsonOrgStorage<List<Autohide
 		@SuppressWarnings("CopyConstructorMissesField")
 		public AutohideItem(AutohideItem autohideItem) {
 			this(autohideItem.chanNames, autohideItem.boardName, autohideItem.threadNumber,
-					autohideItem.optionOriginalPost, autohideItem.optionSage, autohideItem.optionSubject,
-					autohideItem.optionComment, autohideItem.optionName, autohideItem.optionFileName,
+					autohideItem.optionOriginalPost, autohideItem.optionSage, autohideItem.optionEmpty,
+					autohideItem.optionSubject, autohideItem.optionComment, autohideItem.optionName, autohideItem.optionFileName,
 					autohideItem.value);
 		}
 
 		public AutohideItem(HashSet<String> chanNames, String boardName, String threadNumber,
-				boolean optionOriginalPost, boolean optionSage, boolean optionSubject, boolean optionComment,
-				boolean optionName, boolean optionFileName, String value) {
-			update(chanNames, boardName, threadNumber, optionOriginalPost, optionSage,
+							boolean optionOriginalPost, boolean optionSage, boolean optionEmpty, boolean optionSubject,
+							boolean optionComment, boolean optionName, boolean optionFileName, String value) {
+			update(chanNames, boardName, threadNumber, optionOriginalPost, optionSage, optionEmpty,
 					optionSubject, optionComment, optionName, optionFileName, value);
 		}
 
@@ -188,13 +192,14 @@ public class AutohideStorage extends StorageManager.JsonOrgStorage<List<Autohide
 		}
 
 		public void update(HashSet<String> chanNames, String boardName, String threadNumber,
-				boolean optionOriginalPost, boolean optionSage, boolean optionSubject,
+				boolean optionOriginalPost, boolean optionSage, boolean optionEmptyComment, boolean optionSubject,
 				boolean optionComment, boolean optionName, boolean optionFileName, String value) {
 			this.chanNames = chanNames;
 			this.boardName = boardName;
 			this.threadNumber = threadNumber;
 			this.optionOriginalPost = optionOriginalPost;
 			this.optionSage = optionSage;
+			this.optionEmpty = optionEmptyComment;
 			this.optionSubject = optionSubject;
 			this.optionComment = optionComment;
 			this.optionName = optionName;
@@ -246,10 +251,15 @@ public class AutohideStorage extends StorageManager.JsonOrgStorage<List<Autohide
 			if (optionFileName && reasonSource == ReasonSource.FILE) {
 				builder.append("file ");
 			}
+			if (optionComment && optionEmpty && reasonSource == ReasonSource.COMMENT) {
+				builder.append("comment ");
+			}
 			if (!StringUtils.isEmpty(findResult)) {
 				builder.append(findResult);
 			} else if (!StringUtils.isEmpty(text)) {
 				builder.append(StringUtils.cutIfLongerToLine(text, 80, true));
+			} else {
+				builder.append("empty");
 			}
 			return builder.toString();
 		}
@@ -270,6 +280,7 @@ public class AutohideStorage extends StorageManager.JsonOrgStorage<List<Autohide
 			dest.writeByte((byte) (optionComment ? 1 : 0));
 			dest.writeByte((byte) (optionName ? 1 : 0));
 			dest.writeByte((byte) (optionFileName ? 1 : 0));
+			dest.writeByte((byte) (optionEmpty ? 1: 0));
 			dest.writeString(value);
 		}
 
@@ -290,6 +301,7 @@ public class AutohideStorage extends StorageManager.JsonOrgStorage<List<Autohide
 				autohideItem.optionComment = source.readByte() != 0;
 				autohideItem.optionName = source.readByte() != 0;
 				autohideItem.optionFileName = source.readByte() != 0;
+				autohideItem.optionEmpty = source.readByte() != 0;
 				autohideItem.value = source.readString();
 				return autohideItem;
 			}

--- a/src/com/mishiranu/dashchan/ui/preference/AutohideFragment.java
+++ b/src/com/mishiranu/dashchan/ui/preference/AutohideFragment.java
@@ -14,6 +14,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.WindowManager;
 import android.widget.CheckBox;
+import android.widget.CompoundButton;
 import android.widget.EditText;
 import android.widget.ScrollView;
 import android.widget.TextView;
@@ -402,6 +403,15 @@ public class AutohideFragment extends BaseListFragment {
 			valueEdit.addTextChangedListener(valueListener);
 			testStringEdit.addTextChangedListener(testStringListener);
 			chanNameSelector.setOnClickListener(v -> new ChanMultiChoiceDialog(selectedChanNames).show(this));
+			autohideEmpty.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+				@Override
+				public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+					valueEdit.setVisibility(!isChecked ? View.VISIBLE : View.GONE);
+					errorText.setVisibility(!isChecked ? View.VISIBLE : View.GONE);
+					matcherText.setVisibility(!isChecked ? View.VISIBLE : View.GONE);
+					testStringEdit.setVisibility(!isChecked ? View.VISIBLE : View.GONE);
+				}
+			});
 			if (C.API_LOLLIPOP) {
 				chanNameSelector.setTypeface(ResourceUtils.TYPEFACE_MEDIUM);
 			}

--- a/src/com/mishiranu/dashchan/ui/preference/AutohideFragment.java
+++ b/src/com/mishiranu/dashchan/ui/preference/AutohideFragment.java
@@ -255,8 +255,12 @@ public class AutohideFragment extends BaseListFragment {
 		public void onBindViewHolder(@NonNull RecyclerView.ViewHolder holder, int position) {
 			ViewFactory.TwoLinesViewHolder viewHolder = (ViewFactory.TwoLinesViewHolder) holder.itemView.getTag();
 			AutohideStorage.AutohideItem autohideItem = getItem(position);
-			viewHolder.text1.setText(StringUtils.isEmpty(autohideItem.value)
-					? getString(R.string.all_posts) : autohideItem.value);
+			if (!autohideItem.optionEmpty) {
+				viewHolder.text1.setText(StringUtils.isEmpty(autohideItem.value)
+						? getString(R.string.all_posts) : autohideItem.value);
+			} else {
+				viewHolder.text1.setText(R.string.empty_values);
+			}
 			StringBuilder builder = new StringBuilder();
 			boolean and = false;
 			if (!StringUtils.isEmpty(autohideItem.boardName) || autohideItem.optionOriginalPost
@@ -355,6 +359,7 @@ public class AutohideFragment extends BaseListFragment {
 		private EditText threadNumberEdit;
 		private CheckBox autohideOriginalPost;
 		private CheckBox autohideSage;
+		private CheckBox autohideEmpty;
 		private CheckBox autohideSubject;
 		private CheckBox autohideComment;
 		private CheckBox autohideName;
@@ -385,6 +390,7 @@ public class AutohideFragment extends BaseListFragment {
 			threadNumberEdit = view.findViewById(R.id.thread_number);
 			autohideOriginalPost = view.findViewById(R.id.autohide_original_post);
 			autohideSage = view.findViewById(R.id.autohide_sage);
+			autohideEmpty = view.findViewById(R.id.autohide_empty);
 			autohideSubject = view.findViewById(R.id.autohide_subject);
 			autohideComment = view.findViewById(R.id.autohide_comment);
 			autohideName = view.findViewById(R.id.autohide_name);
@@ -418,6 +424,7 @@ public class AutohideFragment extends BaseListFragment {
 				threadNumberEdit.setText(autohideItem.threadNumber);
 				autohideOriginalPost.setChecked(autohideItem.optionOriginalPost);
 				autohideSage.setChecked(autohideItem.optionSage);
+				autohideEmpty.setChecked(autohideItem.optionEmpty);
 				autohideSubject.setChecked(autohideItem.optionSubject);
 				autohideComment.setChecked(autohideItem.optionComment);
 				autohideName.setChecked(autohideItem.optionName);
@@ -429,6 +436,7 @@ public class AutohideFragment extends BaseListFragment {
 				threadNumberEdit.setText(null);
 				autohideOriginalPost.setChecked(false);
 				autohideSage.setChecked(false);
+				autohideEmpty.setChecked(false);
 				autohideSubject.setChecked(true);
 				autohideComment.setChecked(true);
 				autohideName.setChecked(true);
@@ -488,9 +496,10 @@ public class AutohideFragment extends BaseListFragment {
 			boolean optionComment = autohideComment.isChecked();
 			boolean optionName = autohideName.isChecked();
 			boolean optionFileName = autohideFileName.isChecked();
+			boolean optionEmptyComment = autohideEmpty.isChecked();
 			String value = valueEdit.getText().toString();
 			return new AutohideStorage.AutohideItem(selectedChanNames.size() > 0 ? selectedChanNames : null,
-					boardName, threadNumber, optionOriginalPost, optionSage,
+					boardName, threadNumber, optionOriginalPost, optionSage, optionEmptyComment,
 					optionSubject, optionComment, optionName, optionFileName, value);
 		}
 

--- a/src/com/mishiranu/dashchan/ui/preference/AutohideFragment.java
+++ b/src/com/mishiranu/dashchan/ui/preference/AutohideFragment.java
@@ -402,6 +402,12 @@ public class AutohideFragment extends BaseListFragment {
 			autohideOriginalPost = view.findViewById(R.id.autohide_original_post);
 			autohideSage = view.findViewById(R.id.autohide_sage);
 			autohideEmpty = view.findViewById(R.id.autohide_empty);
+			autohideEmpty.setOnCheckedChangeListener((buttonView, isChecked) -> {
+				valueEdit.setVisibility(isChecked ? View.GONE : View.VISIBLE);
+				errorText.setVisibility(isChecked ? View.GONE : View.VISIBLE);
+				matcherText.setVisibility(isChecked ? View.GONE : View.VISIBLE);
+				testStringEdit.setVisibility(isChecked ? View.GONE : View.VISIBLE);
+			});
 			autohideSubject = view.findViewById(R.id.autohide_subject);
 			autohideComment = view.findViewById(R.id.autohide_comment);
 			autohideName = view.findViewById(R.id.autohide_name);
@@ -413,15 +419,6 @@ public class AutohideFragment extends BaseListFragment {
 			valueEdit.addTextChangedListener(valueListener);
 			testStringEdit.addTextChangedListener(testStringListener);
 			chanNameSelector.setOnClickListener(v -> new ChanMultiChoiceDialog(selectedChanNames).show(this));
-			autohideEmpty.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
-				@Override
-				public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-					valueEdit.setVisibility(!isChecked ? View.VISIBLE : View.GONE);
-					errorText.setVisibility(!isChecked ? View.VISIBLE : View.GONE);
-					matcherText.setVisibility(!isChecked ? View.VISIBLE : View.GONE);
-					testStringEdit.setVisibility(!isChecked ? View.VISIBLE : View.GONE);
-				}
-			});
 			if (C.API_LOLLIPOP) {
 				chanNameSelector.setTypeface(ResourceUtils.TYPEFACE_MEDIUM);
 			}

--- a/src/com/mishiranu/dashchan/ui/preference/AutohideFragment.java
+++ b/src/com/mishiranu/dashchan/ui/preference/AutohideFragment.java
@@ -262,6 +262,16 @@ public class AutohideFragment extends BaseListFragment {
 			} else {
 				viewHolder.text1.setText(R.string.empty_values);
 			}
+			if (autohideItem.chanNames != null) {
+				StringBuilder forChans = new StringBuilder(viewHolder.text1.getText() + " - ");
+				if (autohideItem.chanNames.size() == 1) {
+					forChans.append((String)(autohideItem.chanNames.toArray()[0]));
+				}
+				else {
+					forChans.append(getString(R.string.multiple_forums));
+				}
+				viewHolder.text1.setText(forChans.toString());
+			}
 			StringBuilder builder = new StringBuilder();
 			boolean and = false;
 			if (!StringUtils.isEmpty(autohideItem.boardName) || autohideItem.optionOriginalPost


### PR DESCRIPTION
At the moment, it is not possible to configure auto-hide rules so that posts containing empty values can be hidden. If we try to leave the regular expression line empty, Dashchan hides everything.

I added custom rules for hiding based on empty values. When user select the appropriate item in the rules settings, the behavior will change automatically. In case of a rule, Dashchan will check if the value of title/comment/name/filename is not empty. The user can choose which values to perform checks in (I’m not sure if this is relevant for the name, since each module has a default name for anonymous, but I left this option)

+ Minor changes to the display, allowing to see in the list whether the rule was created for every forum, for one forum or multiple