### PR TITLE
Add host header to http requests

### DIFF
--- a/src/chan/http/HttpClient.java
+++ b/src/chan/http/HttpClient.java
@@ -438,6 +438,7 @@ public class HttpClient {
 			connection.setConnectTimeout(request.connectTimeout);
 			connection.setReadTimeout(request.readTimeout);
 			connection.setInstanceFollowRedirects(false);
+			connection.setRequestProperty("Host", url.getHost());
 			connection.setRequestProperty("Connection", request.keepAlive ? "keep-alive" : "close");
 			String userAgent = null;
 			boolean userAgentSet = false;


### PR DESCRIPTION
Host header is mandatory in HTTP 1.1 and some sites won't work properly without it (e.g. 2ch.life won't pass cloudflare check if there's no host header or if host header is placed after user agent header).