### PR TITLE
Cache improvements

### DIFF
--- a/lang/values-ru/strings.xml
+++ b/lang/values-ru/strings.xml
@@ -588,4 +588,6 @@
 	<string name="new_filename">Новое имя файла</string>
 	<string name="space_after_quote">Добавлять пробел после цитирования</string>
 	<string name="rename_to_jpg">Переименовать в .jpg</string>
+	<string name="use_internal_storage_for_cache">Использовать внутреннее хранилище для кэша</string>
+	<string name="use_internal_storage_for_cache__summary">Активируйте только если есть проблемы с кэшем</string>
 </resources>

--- a/lang/values/strings.xml
+++ b/lang/values/strings.xml
@@ -570,4 +570,6 @@
 	<string name="new_filename">New filename</string>
 	<string name="space_after_quote">Add space after quote</string>
 	<string name="rename_to_jpg">Rename to .jpg</string>
+	<string name="use_internal_storage_for_cache">Use internal storage for cache</string>
+	<string name="use_internal_storage_for_cache__summary">Activate only if there are issues with cache</string>
 </resources>

--- a/src/com/mishiranu/dashchan/content/CacheManager.java
+++ b/src/com/mishiranu/dashchan/content/CacheManager.java
@@ -642,4 +642,46 @@ public class CacheManager implements Runnable {
 		Uri getUri(File directory, File file, String mimeType);
 	}
 
+	public static class CacheException extends Exception {
+
+		public CacheException(String errorMessage) {
+			super(errorMessage);
+		}
+
+	}
+
+	public File getMediaFileOrThrow(Uri uri, boolean touch) throws CacheException  {
+		File directory = getMediaDirectoryOrThrow();
+		String fileName = getCachedFileKey(uri);
+		File file = new File(directory, fileName);
+		if (touch) {
+			updateCachedFileLastModified(file, fileName, CacheItem.Type.MEDIA);
+		}
+		return file;
+	}
+
+	public File getMediaDirectoryOrThrow() throws CacheException {
+		if (!isCacheAvailable()) {
+			throw new CacheException("Cache storage is not available");
+		}
+
+		File cacheDirectory = getCacheDirectory();
+		if (cacheDirectory == null) {
+			throw new CacheException("Cache directory is not available");
+		}
+		if (!cacheDirectory.exists()) {
+			throw new CacheException("Cache directory doesn't exist");
+		}
+
+		File mediaCacheDirectory = new File(cacheDirectory, "media");
+		if (!mediaCacheDirectory.exists()) {
+			boolean mediaCacheDirectoryCreated = mediaCacheDirectory.mkdirs();
+			if (!mediaCacheDirectoryCreated) {
+				throw new CacheException("Cannot create media cache directory");
+			}
+		}
+
+		return mediaCacheDirectory;
+	}
+
 }

--- a/src/com/mishiranu/dashchan/content/Preferences.java
+++ b/src/com/mishiranu/dashchan/content/Preferences.java
@@ -1552,5 +1552,12 @@ public class Preferences {
 		return PREFERENCES.getBoolean(KEY_SPACE_AFTER_QUOTE, DEFAULT_SPACE_AFTER_QUOTE);
 	}
 
+	public static final String KEY_USE_INTERNAL_STORAGE_FOR_CACHE = "use_internal_storage_for_cache";
+	public static final boolean DEFAULT_USE_INTERNAL_STORAGE_FOR_CACHE = false;
+
+	public static boolean isUseInternalStorageForCache(){
+		return PREFERENCES.getBoolean(KEY_USE_INTERNAL_STORAGE_FOR_CACHE, DEFAULT_USE_INTERNAL_STORAGE_FOR_CACHE);
+	}
+
 
 }

--- a/src/com/mishiranu/dashchan/ui/gallery/PagerUnit.java
+++ b/src/com/mishiranu/dashchan/ui/gallery/PagerUnit.java
@@ -305,14 +305,19 @@ public class PagerUnit implements PagerInstance.Callback {
 		}
 		holder.playButton.setVisibility(View.GONE);
 		Uri uri = galleryItem.getFileUri(chan);
-		File cachedFile = cacheManager.getMediaFile(uri, true);
-		if (cachedFile == null) {
-			showError(holder, galleryInstance.context.getString(R.string.cache_is_unavailable));
-		} else if (isImage) {
-			imageUnit.applyImage(uri, cachedFile, reload);
-		} else if (isVideo) {
-			imageUnit.interrupt(true);
-			videoUnit.applyVideo(uri, cachedFile, reload);
+		try {
+			File cachedFile = cacheManager.getMediaFileOrThrow(uri, true);
+			if (cachedFile == null) {
+				showError(holder, "Cached file not found");
+			} else if (isImage) {
+				imageUnit.applyImage(uri, cachedFile, reload);
+			} else if (isVideo) {
+				imageUnit.interrupt(true);
+				videoUnit.applyVideo(uri, cachedFile, reload);
+			}
+		}
+		catch (CacheManager.CacheException e){
+			showError(holder, e.getMessage());
 		}
 	}
 

--- a/src/com/mishiranu/dashchan/ui/preference/MediaFragment.java
+++ b/src/com/mishiranu/dashchan/ui/preference/MediaFragment.java
@@ -26,6 +26,7 @@ import com.mishiranu.dashchan.content.async.TaskViewModel;
 import com.mishiranu.dashchan.media.VideoPlayer;
 import com.mishiranu.dashchan.ui.FragmentHandler;
 import com.mishiranu.dashchan.ui.InstanceDialog;
+import com.mishiranu.dashchan.ui.preference.core.CheckPreference;
 import com.mishiranu.dashchan.ui.preference.core.EditPreference;
 import com.mishiranu.dashchan.ui.preference.core.Preference;
 import com.mishiranu.dashchan.ui.preference.core.PreferenceFragment;
@@ -170,6 +171,11 @@ public class MediaFragment extends PreferenceFragment implements FragmentHandler
 
 		addDependency(Preferences.KEY_SUBDIR_PATTERN, Preferences.KEY_DOWNLOAD_SUBDIR, false,
 				Preferences.DownloadSubdirMode.DISABLED.value);
+		CheckPreference useInternalStorageForCachePreference = addCheck(true, Preferences.KEY_USE_INTERNAL_STORAGE_FOR_CACHE, Preferences.DEFAULT_USE_INTERNAL_STORAGE_FOR_CACHE,R.string.use_internal_storage_for_cache, R.string.use_internal_storage_for_cache__summary);
+		useInternalStorageForCachePreference.setOnAfterChangeListener(p -> {
+			CacheManager.getInstance().rebuildCache();
+			clearCachePreference.invalidate();
+		});
 	}
 
 	@Override


### PR DESCRIPTION
Some users have reported an issue with the cache resulting in an error message "cache is not available" in the gallery. However, I have not been able to replicate this issue on my own devices.  

Commit 2f3fdccead9c688e1c71a8ff72cc86063bc93e8d adds an option to use internal storage for cache, that should help if the problem is that some devices / roms don't create the app's specific directory or cache directory on external storage until proper fix is implemented.

 Commit c5f31927da699248cba025483437e84534d110b2 replaces generic "cache is not available" error message in the gallery with more specific message to make it easier to find the real cause of the issue.