### PR TITLE
Use CacheManager to obtain cache directory for post attachments

### DIFF
--- a/src/com/mishiranu/dashchan/content/CacheManager.java
+++ b/src/com/mishiranu/dashchan/content/CacheManager.java
@@ -547,7 +547,7 @@ public class CacheManager implements Runnable {
 		syncCache();
 	}
 
-	private File getCacheDirectory() {
+	public File getCacheDirectory() {
 		if (cacheDirectory == null) {
 			synchronized (directoryLocker) {
 				if (cacheDirectory == null) {

--- a/src/com/mishiranu/dashchan/content/storage/DraftsStorage.java
+++ b/src/com/mishiranu/dashchan/content/storage/DraftsStorage.java
@@ -5,7 +5,7 @@ import android.os.Parcelable;
 import android.os.SystemClock;
 import android.util.Pair;
 
-import com.mishiranu.dashchan.content.MainApplication;
+import com.mishiranu.dashchan.content.CacheManager;
 import com.mishiranu.dashchan.content.async.ReadCaptchaTask;
 import com.mishiranu.dashchan.content.model.FileHolder;
 import com.mishiranu.dashchan.ui.CaptchaForm;
@@ -191,7 +191,7 @@ public class DraftsStorage extends StorageManager.Storage<Pair<List<DraftsStorag
 	}
 
 	private static File getAttachmentDraftsDirectory() {
-		File directory = MainApplication.getInstance().getExternalCacheDir();
+		File directory = CacheManager.getInstance().getCacheDirectory();
 		if (directory != null) {
 			directory = new File(directory, "attachments");
 			if (directory.isDirectory() || directory.mkdirs()) {


### PR DESCRIPTION
Some devices have an issue where users cannot attach media files to their posts because the "getExternalCacheDir" function returns null and DraftsStorage requires this directory to store post attachments. However, commit 2f3fdccead9c688e1c71a8ff72cc86063bc93e8d has an option that allows the use of internal storage for cache. By enabling this option and implementing the changes as per this commit, users can now attach media files to posts even if the external cache directory cannot be used.