### PR TITLE
Fix slow video playback with HE-AACv2 audio

### DIFF
--- a/jni/src/player/player.c
+++ b/jni/src/player/player.c
@@ -1319,6 +1319,14 @@ void init(JNIEnv * env, jlong pointer, jobject nativeBridge, jboolean seekAnyFra
 		SLresult result;
 		int success = 0;
 		int channels = player->av.audioContext->channels;
+		// HE-AACv2 may initially report its mono core here, while decoded frames
+		// contain parametric-stereo PCM. Keep the OpenSL format equal to the
+		// resampler output; otherwise its audio clock runs at half speed.
+		if (player->av.audioContext->codec_id == AV_CODEC_ID_AAC &&
+				player->av.audioContext->profile == FF_PROFILE_AAC_HE_V2 && channels == 1) {
+			channels = 2;
+			player->audio.resampleChannels = AV_CH_FRONT_LEFT | AV_CH_FRONT_RIGHT;
+		}
 		if (channels != 1 && channels != 2) {
 			channels = 2;
 			player->audio.resampleChannels = AV_CH_FRONT_LEFT | AV_CH_FRONT_RIGHT;


### PR DESCRIPTION
## Problem

HE-AACv2 streams can expose a mono core in AVCodecContext, while decoded frames contain stereo PCM. The player created an OpenSL mono output but calculated the audio clock from stereo frames.

This caused video playback to run at about half speed.

## Fix

Force stereo OpenSL output and resampling for AAC HE-AACv2 streams that initially report one channel.

## Verification

Tested on Samsung Galaxy S25 Ultra, Android 16:

- affected H.264 MP4 with HE-AACv2 plays at normal speed;
- the same file without audio had already played normally;
- ffprobe confirms decoded audio frames are stereo;
- device log previously showed OpenSL output configured as mono.